### PR TITLE
Force MatplotlibViewer to display

### DIFF
--- a/fipy/viewers/matplotlibViewer/matplotlibViewer.py
+++ b/fipy/viewers/matplotlibViewer/matplotlibViewer.py
@@ -154,6 +154,8 @@ class AbstractMatplotlibViewer(AbstractViewer):
             pass
         
         pylab.ion()
+        
+        pylab.show(block=False)
 
         if filename is not None:
             pylab.savefig(filename)


### PR DESCRIPTION
Matplotlib 1.4 seems to have changed when it shows things when not in
interactive mode. `block=False` prevents the viewer from grabbing focus.

Addresses issue427
