### PR TITLE
Issue443 matplotlib viewer still has problems in IPython notebook

### DIFF
--- a/examples/cahnHilliard/sphereDaemon.py
+++ b/examples/cahnHilliard/sphereDaemon.py
@@ -12,10 +12,8 @@ class SphereDaemon(MayaviDaemon):
     def view_data(self):
         """Sets up the mayavi pipeline for the visualization.
         """
-        var = mlab.pipeline.set_active_attribute(self.cellsource, cell_scalars=r"$\phi$")
-        
         if hasattr(mlab.pipeline, "data_set_clipper"):
-            clip = mlab.pipeline.data_set_clipper(var)
+            clip = mlab.pipeline.data_set_clipper(self.cellsource)
 
             clip.widget.widget_mode = 'Box'
             clip.widget.widget.place_factor = 1.


### PR DESCRIPTION
Automatically uses `clear_output()` and `display_png()` when rendering inline in the IPython notebook.

Fixes #443