### PR TITLE
Clear pdflatex build errors by removing :term:`Python` from heading

### DIFF
--- a/documentation/design.rst
+++ b/documentation/design.rst
@@ -190,13 +190,11 @@ is more palatable to the computer than to the programmer.  Thus
 code first and then dealing with the issue of user interaction,
 initially implements most modules in high-level scripting language and
 only translates to low-level compiled code those portions that prove
-inefficient. 
+inefficient [#]_. 
 
-.. A discussion of efficiency issues can be found in
-   :ref:`chap:Efficiency`.
 
-:term:`Python` Programming Language
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Python Programming Language
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Acknowledging that several scripting languages offer a number, if not
 all, of the features described above, we have selected :term:`Python` for
@@ -316,3 +314,6 @@ the examples, along with illustrations of their instantiation and use.
 .. rubric:: Footnotes
 
 .. [#] ... neglecting such common optimizations as byte-code interpreters.
+
+.. [#] A discussion of efficiency issues can be found in
+   :ref:`chap:Efficiency`.


### PR DESCRIPTION
Using :term:`Python` Programming Language as a header in design.rst
produces incomplete/erroneous \def's in fipy.toc. pdflatex then
requests user intervention to clear the error. The crude fix is to
remove the :term: tag from the heading. The root cause may be in
Sphinx, or there may be an elegant way to hide the restructured
text markup from makeindex.