### PR TITLE
Updated to NumPy1.10

### DIFF
--- a/examples/diffusion/steadyState/otherMeshes/grid3Dinput.py
+++ b/examples/diffusion/steadyState/otherMeshes/grid3Dinput.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-## 
+##
  # ###################################################################
  #  FiPy - Python-based finite volume PDE solver
- # 
+ #
  #  FILE: "grid3Dinput.py"
  #
  #  Author: Jonathan Guyer <guyer@nist.gov>
@@ -11,7 +11,7 @@
  #  Author: James Warren   <jwarren@nist.gov>
  #    mail: NIST
  #     www: http://www.ctcms.nist.gov/fipy/
- #  
+ #
  # ========================================================================
  # This software was developed at the National Institute of Standards
  # and Technology by employees of the Federal Government in the course
@@ -22,13 +22,13 @@
  # other parties, and makes no guarantees, expressed or implied, about
  # its quality, reliability, or any other characteristic.  We would
  # appreciate acknowledgement if the software is used.
- # 
+ #
  # This software can be redistributed and/or modified freely
  # provided that any derivative works bear some notice that they are
  # derived from it, and any modified versions bear some notice that
  # they have been modified.
  # ========================================================================
- #  
+ #
  # ###################################################################
  ##
 
@@ -37,15 +37,15 @@
 
 """
 Test case for the Grid3D.
- 
+
    >>> DiffusionTerm().solve(var)
    >>> DiffusionTerm().solve(var2)
    >>> a = numerix.array(var.globalValue)
    >>> b = numerix.array(var2.globalValue)
    >>> c = numerix.ravel(numerix.array((b, b, b)))
    >>> print numerix.allclose(a, c)
-   1
-   
+   True
+
 """
 
 from fipy import *
@@ -91,7 +91,7 @@ var2.constrain(valueLeftRight, mesh2.facesRight)
 var2.constrain(valueBottomTop, mesh2.facesTop)
 var2.constrain(valueBottomTop, mesh2.facesBottom)
 
-eqn = DiffusionTerm()  
+eqn = DiffusionTerm()
 
 if __name__ == '__main__':
     eqn.solve(var2)

--- a/fipy/meshes/uniformGrid3D.py
+++ b/fipy/meshes/uniformGrid3D.py
@@ -3,7 +3,7 @@
 ## -*-Pyth-*-
  # ########################################################################
  # FiPy - a finite volume PDE solver in Python
- # 
+ #
  # FILE: "uniformGrid3D.py"
  #
  #  Author: Jonathan Guyer <guyer@nist.gov>
@@ -12,7 +12,7 @@
  #  Author: James O'Beirne <james.obeirne@gmail.com>
  #   mail: NIST
  #    www: <http://www.ctcms.nist.gov/fipy/>
- #  
+ #
  # ========================================================================
  # This software was developed at the National Institute of Standards
  # and Technology by employees of the Federal Government in the course
@@ -23,13 +23,13 @@
  # other parties, and makes no guarantees, expressed or implied, about
  # its quality, reliability, or any other characteristic.  We would
  # appreciate acknowledgement if the software is used.
- # 
+ #
  # This software can be redistributed and/or modified freely
- # provided that any derivative works bear some notice that they are 
+ # provided that any derivative works bear some notice that they are
  # derived from it, and any modified versions bear some notice that
  # they have been modified.
  # ========================================================================
- # 
+ #
  # ########################################################################
  ##
 
@@ -56,14 +56,14 @@ class UniformGrid3D(UniformGrid):
     Numbering System:
 
     Vertices: Numbered in the usual way. X coordinate changes most quickly, then Y, then Z.
-    
+
     *** arrays are arranged Z, Y, X because in numerix, the final index is the one that changes the most quickly ***
 
     Cells: Same numbering system as vertices.
 
     Faces: XY faces numbered first, then XZ faces, then YZ faces. Within each subcategory, it is numbered in the usual way.
     """
-    def __init__(self, dx = 1., dy = 1., dz = 1., nx = 1, ny = 1, nz = 1, 
+    def __init__(self, dx = 1., dy = 1., dz = 1., nx = 1, ny = 1, nz = 1,
                  origin = [[0], [0], [0]], overlap=2, communicator=parallelComm,
                  _RepresentationClass=_Grid3DRepresentation,
                  _TopologyClass=_Grid3DTopology):
@@ -75,20 +75,20 @@ class UniformGrid3D(UniformGrid):
         builder = _UniformGrid3DBuilder()
 
         self.args = {
-            'dx': dx, 
+            'dx': dx,
             'dy': dy,
             'dz': dz,
-            'nx': nx, 
+            'nx': nx,
             'ny': ny,
             'nz': nz,
             'origin': origin,
             'overlap': overlap,
             'communicator': communicator
         }
-        
-        builder.buildGridData([dx, dy, dz], [nx, ny, nz], overlap, 
+
+        builder.buildGridData([dx, dy, dz], [nx, ny, nz], overlap,
                               communicator, origin)
-                                                        
+
         ([self.dx, self.dy, self.dz],
          [self.nx, self.ny, self.nz],
          self.dim,
@@ -110,7 +110,7 @@ class UniformGrid3D(UniformGrid):
          self.numberOfVerticalColumns,
          self.numberOfLayers,
          self.origin) = builder.gridData
-        
+
     """
     Topology set and calc
     """
@@ -123,14 +123,14 @@ class UniformGrid3D(UniformGrid):
         XYids = self._XYFaceIDs
         XZids = self._XZFaceIDs
         YZids = self._YZFaceIDs
-        
-        exteriorIDs = numerix.concatenate((numerix.ravel(XYids[...,      0].swapaxes(0,1)), 
+
+        exteriorIDs = numerix.concatenate((numerix.ravel(XYids[...,      0].swapaxes(0,1)),
                                            numerix.ravel(XYids[...,     -1].swapaxes(0,1)),
-                                           numerix.ravel(XZids[...,  0,...]), 
+                                           numerix.ravel(XZids[...,  0,...]),
                                            numerix.ravel(XZids[..., -1,...]),
-                                           numerix.ravel(YZids[ 0,     ...]), 
+                                           numerix.ravel(YZids[ 0,     ...]),
                                            numerix.ravel(YZids[-1,     ...])))
-                                                     
+
         from fipy.variables.faceVariable import FaceVariable
         exteriorFaces = FaceVariable(mesh=self, value=False)
         exteriorFaces[exteriorIDs] = True
@@ -144,11 +144,11 @@ class UniformGrid3D(UniformGrid):
         XYids = self._XYFaceIDs
         XZids = self._XZFaceIDs
         YZids = self._YZFaceIDs
-        
+
         interiorIDs = numerix.concatenate((numerix.ravel(XYids[ ...     ,1:-1]),
                                            numerix.ravel(XZids[ ...,1:-1, ...]),
                                            numerix.ravel(YZids[1:-1,      ...].swapaxes(0,1))))
-                                                     
+
         from fipy.variables.faceVariable import FaceVariable
         interiorFaces = FaceVariable(mesh=self, value=False)
         interiorFaces[interiorIDs] = True
@@ -175,7 +175,7 @@ class UniformGrid3D(UniformGrid):
         ids[3] = indices[0] + (indices[1] + indices[2] * self.ny + self.nz) * self.nx
         ids[4] = indices[0] + (indices[1] + (indices[2] - 1) * self.ny) * self.nx
         ids[5] = indices[0] + (indices[1] + (indices[2] + 1) * self.ny) * self.nx
-        
+
         ids[0, 0,    ...] = MA.masked
         ids[1,-1,    ...] = MA.masked
         ids[2,..., 0,...] = MA.masked
@@ -184,15 +184,15 @@ class UniformGrid3D(UniformGrid):
         ids[5,...,    -1] = MA.masked
 
         return MA.reshape(ids.swapaxes(1,3), (6, self.numberOfCells))
-        
+
     @property
     def _cellToCellIDsFilled(self):
         N = self.numberOfCells
         M = self._maxFacesPerCell
         cellIDs = numerix.repeat(numerix.arange(N)[numerix.newaxis, ...], M, axis=0)
         cellToCellIDs = self._cellToCellIDs
-        return MA.where(MA.getmaskarray(cellToCellIDs), cellIDs, cellToCellIDs)     
-                                                                                                
+        return MA.where(MA.getmaskarray(cellToCellIDs), cellIDs, cellToCellIDs)
+
     """
     Geometry set and calc
     """
@@ -216,9 +216,9 @@ class UniformGrid3D(UniformGrid):
         YZnor = numerix.zeros((3, self.nx + 1, self.ny, self.nz), 'l')
         YZnor[2,      ...] =  1
         YZnor[2, 0,   ...] = -1
-        
-        return numerix.concatenate((numerix.reshape(XYnor[::-1].swapaxes(1,3), (3, self.numberOfXYFaces)), 
-                                    numerix.reshape(XZnor[::-1].swapaxes(1,3), (3, self.numberOfXZFaces)), 
+
+        return numerix.concatenate((numerix.reshape(XYnor[::-1].swapaxes(1,3), (3, self.numberOfXYFaces)),
+                                    numerix.reshape(XZnor[::-1].swapaxes(1,3), (3, self.numberOfXZFaces)),
                                     numerix.reshape(YZnor[::-1].swapaxes(1,3), (3, self.numberOfYZFaces))), axis=1)
 
     @property
@@ -241,7 +241,7 @@ class UniformGrid3D(UniformGrid):
         XYdis[:] = self.dz
         XYdis[ 0,...] = self.dz / 2.
         XYdis[-1,...] = self.dz / 2.
-        
+
         XZdis = numerix.zeros((self.nz, self.ny + 1, self.nx),'d')
         XZdis[:] = self.dy
         XZdis[..., 0,...] = self.dy / 2.
@@ -262,21 +262,21 @@ class UniformGrid3D(UniformGrid):
         XYdis[:] = 0.5
         XYdis[..., 0] = 1
         XYdis[...,-1] = 1
-        
+
         XZdis = numerix.zeros((self.nx, self.ny + 1, self.nz),'d')
         XZdis[:] = 0.5
         XZdis[..., 0,...] = 1
         XZdis[...,-1,...] = 1
-        
+
         YZdis = numerix.zeros((self.nx + 1, self.ny, self.nz),'d')
         YZdis[:] = 0.5
         YZdis[ 0,...] = 1
         YZdis[-1,...] = 1
-        
+
         return numerix.concatenate((numerix.ravel(XYdis.swapaxes(0,2)),
                                     numerix.ravel(XZdis.swapaxes(0,2)),
-                                    numerix.ravel(YZdis.swapaxes(0,2))), axis=1)
-    
+                                    numerix.ravel(YZdis.swapaxes(0,2))))
+
     @property
     def _orientedFaceNormals(self):
         return self.faceNormals
@@ -285,32 +285,32 @@ class UniformGrid3D(UniformGrid):
     def _faceTangents1(self):
         XYtan = numerix.zeros((3, self.nx, self.ny, self.nz + 1), 'l')
         XYtan[2,      ...] =  1
-        
+
         XZtan = numerix.zeros((3, self.nx, self.ny + 1, self.nz), 'l')
         XZtan[2,      ...] =  1
-        
+
         YZtan = numerix.zeros((3, self.nx + 1, self.ny, self.nz), 'l')
         YZtan[1,      ...] =  1
-        
-        return numerix.concatenate((numerix.reshape(XYtan[::-1].swapaxes(1,3), (3, self.numberOfXYFaces)), 
-                                    numerix.reshape(XZtan[::-1].swapaxes(1,3), (3, self.numberOfXZFaces)), 
+
+        return numerix.concatenate((numerix.reshape(XYtan[::-1].swapaxes(1,3), (3, self.numberOfXYFaces)),
+                                    numerix.reshape(XZtan[::-1].swapaxes(1,3), (3, self.numberOfXZFaces)),
                                     numerix.reshape(YZtan[::-1].swapaxes(1,3), (3, self.numberOfYZFaces))), axis=1)
-        
+
     @property
     def _faceTangents2(self):
         XYtan = numerix.zeros((3, self.nx, self.ny, self.nz + 1), 'l')
         XYtan[1,      ...] =  1
-        
+
         XZtan = numerix.zeros((3, self.nx, self.ny + 1, self.nz), 'l')
         XZtan[0,      ...] =  1
-        
+
         YZtan = numerix.zeros((3, self.nx + 1, self.ny, self.nz), 'l')
         YZtan[0,      ...] =  1
-        
-        return numerix.concatenate((numerix.reshape(XYtan[::-1].swapaxes(1,3), (3, self.numberOfXYFaces)), 
-                                    numerix.reshape(XZtan[::-1].swapaxes(1,3), (3, self.numberOfXZFaces)), 
+
+        return numerix.concatenate((numerix.reshape(XYtan[::-1].swapaxes(1,3), (3, self.numberOfXYFaces)),
+                                    numerix.reshape(XZtan[::-1].swapaxes(1,3), (3, self.numberOfXZFaces)),
                                     numerix.reshape(YZtan[::-1].swapaxes(1,3), (3, self.numberOfYZFaces))), axis=1)
-    
+
     @property
     def _cellToCellDistances(self):
         distances = numerix.zeros((6, self.nx, self.ny, self.nz), 'd')
@@ -320,7 +320,7 @@ class UniformGrid3D(UniformGrid):
         distances[3] = self.dy
         distances[4] = self.dz
         distances[5] = self.dz
-        
+
         distances[0,  0,...    ] = self.dx / 2.
         distances[1, -1,...    ] = self.dx / 2.
         distances[2,...,  0,...] = self.dy / 2.
@@ -329,7 +329,7 @@ class UniformGrid3D(UniformGrid):
         distances[5,...,     -1] = self.dz / 2.
 
         return numerix.reshape(distances.swapaxes(1,3), (self.numberOfCells, 6))
-        
+
     @property
     def _cellNormals(self):
         normals = numerix.zeros((3, 6, self.numberOfCells), 'd')
@@ -341,7 +341,7 @@ class UniformGrid3D(UniformGrid):
         normals[...,5,...] = [[ 0], [ 0], [ 1]]
 
         return normals
-        
+
     @property
     def _cellAreas(self):
         areas = numerix.ones((6, self.numberOfCells), 'd')
@@ -361,7 +361,7 @@ class UniformGrid3D(UniformGrid):
 
     @property
     def _faceCenters(self):
-                                  
+
         XYcen = numerix.zeros((3, self.nx, self.ny, self.nz + 1), 'd')
         indices = numerix.indices((self.nx, self.ny, self.nz + 1))
         XYcen[0] = (indices[0] + 0.5) * self.dx
@@ -373,17 +373,17 @@ class UniformGrid3D(UniformGrid):
         XZcen[0] = (indices[0] + 0.5) * self.dx
         XZcen[1] = indices[1] * self.dy
         XZcen[2] = (indices[2] + 0.5) * self.dz
-        
+
         YZcen = numerix.zeros((3, self.nx + 1, self.ny, self.nz), 'd')
         indices = numerix.indices((self.nx + 1, self.ny, self.nz))
         YZcen[0] = indices[0] * self.dx
         YZcen[1] = (indices[1] + 0.5) * self.dy
         YZcen[2] = (indices[2] + 0.5) * self.dz
 
-        return numerix.concatenate((numerix.reshape(XYcen.swapaxes(1,3), (3, self.numberOfXYFaces)), 
+        return numerix.concatenate((numerix.reshape(XYcen.swapaxes(1,3), (3, self.numberOfXYFaces)),
                                     numerix.reshape(XZcen.swapaxes(1,3), (3, self.numberOfXZFaces)),
                                     numerix.reshape(YZcen.swapaxes(1,3), (3, self.numberOfYZFaces))), axis=1) + self.origin
-                                                                 
+
     @property
     def _orientedAreaProjections(self):
         return self._areaProjections
@@ -391,21 +391,21 @@ class UniformGrid3D(UniformGrid):
     @property
     def _areaProjections(self):
         return self.faceNormals * self._faceAreas
-     
+
     @property
     def _faceAspectRatios(self):
-        return self._faceAreas / self._cellDistances  
-         
+        return self._faceAreas / self._cellDistances
+
     def _translate(self, vector):
-        return self.__class__(dx = self.args['dx'], nx = self.args['nx'], 
+        return self.__class__(dx = self.args['dx'], nx = self.args['nx'],
                               dy = self.args['dy'], ny = self.args['ny'],
                               dz = self.args['dz'], nz = self.args['nz'],
                              origin = numerix.array(self.args['origin']) + vector, overlap=self.args['overlap'])
-        
+
     def __mul__(self, factor):
-        return UniformGrid3D(dx = self.dx * factor, nx = self.nx, 
-                             dy = self.dy * factor, ny = self.ny, 
-                             dz = self.dz * factor, nz = self.nz, 
+        return UniformGrid3D(dx = self.dx * factor, nx = self.nx,
+                             dy = self.dy * factor, ny = self.ny,
+                             dz = self.dz * factor, nz = self.nz,
                              origin = self.origin * factor)
 
     @property
@@ -441,18 +441,18 @@ class UniformGrid3D(UniformGrid):
     def _YZFaceIDs(self):
         ids = numerix.arange(self.numberOfXYFaces + self.numberOfXZFaces, self.numberOfFaces)
         return ids.reshape((self.nz, self.ny, self.nx + 1)).swapaxes(0,2)
-   
+
     @property
     def _maxFacesPerCell(self):
         return 6
-        
+
 ##         from numMesh/mesh
 
     @property
     def vertexCoords(self):
         return _Grid3DBuilder.createVertices(self.dx, self.dy, self.dz,
                                              self.nx, self.ny, self.nz,
-                                             self.numberOfVertices,     
+                                             self.numberOfVertices,
                                              self.numberOfHorizontalRows,
                                              self.numberOfVerticalColumns) \
                 + self.origin
@@ -466,7 +466,7 @@ class UniformGrid3D(UniformGrid):
         XYids[0,..., 0] = XYids[1,..., 0]
         XYids[1,..., 0] = MA.masked
         XYids[1,...,-1] = MA.masked
-        
+
         XZids = MA.zeros((2, self.nx, self.ny + 1, self.nz), 'l')
         indices = numerix.indices((self.nx, self.ny + 1, self.nz))
         XZids[1] = indices[0] + (indices[1] + indices[2] * self.ny) * self.nx
@@ -483,12 +483,12 @@ class UniformGrid3D(UniformGrid):
         YZids[1, 0] = MA.masked
         YZids[1,-1] = MA.masked
 
-        return MA.concatenate((XYids.swapaxes(1,3).reshape((2, self.numberOfXYFaces)), 
-                               XZids.swapaxes(1,3).reshape((2, self.numberOfXZFaces)), 
+        return MA.concatenate((XYids.swapaxes(1,3).reshape((2, self.numberOfXYFaces)),
+                               XZids.swapaxes(1,3).reshape((2, self.numberOfXZFaces)),
                                YZids.swapaxes(1,3).reshape((2, self.numberOfYZFaces))), axis=1)
 
 ##         from common/mesh
-     
+
     @property
     def _cellVertexIDs(self):
         return self._orderedCellVertexIDs
@@ -509,21 +509,21 @@ class UniformGrid3D(UniformGrid):
         ids[4] = ids[5] + 1
         ids[7] = indices[0] + (indices[1] + indices[2] * (self.ny + 1)) * (self.nx + 1)
         ids[6] = ids[7] + 1
-        
+
         return numerix.reshape(ids.swapaxes(1,3), (8, self.numberOfCells))
-        
+
 ##     scaling
-    
+
     def _getNearestCellID(self, points):
         nx = self.args['nx']
         ny = self.args['ny']
         nz = self.args['nz']
-        
-        x0, y0, z0 = self.cellCenters[...,0]        
+
+        x0, y0, z0 = self.cellCenters[...,0]
         xi, yi, zi = points
         nx, ny, nz = self.shape
         dx, dy, dz = self.dx, self.dy, self.dz
-        
+
         i = numerix.array(numerix.rint(((xi - x0) / dx)), 'l')
         i[i < 0] = 0
         i[i > nx - 1] = nx - 1
@@ -535,14 +535,14 @@ class UniformGrid3D(UniformGrid):
         k = numerix.array(numerix.rint(((zi - z0) / dz)), 'l')
         k[k < 0] = 0
         k[k > nz - 1]  = nz - 1
-        
+
         return k * ny * nx + j * nx + i
-        
+
     def _test(self):
         """
         These tests are not useful as documentation, but are here to ensure
         everything works as expected.
-        
+
             >>> dx = 0.5
             >>> dy = 2.
             >>> dz = 4.
@@ -557,13 +557,13 @@ class UniformGrid3D(UniformGrid):
             ...                            ((2, 8), (5, 11))))
             >>> print numerix.allequal(XYFaceIDs, mesh._XYFaceIDs) # doctest: +PROCESSOR_0
             True
-              
+
             >>> XZFaceIDs = numerix.array((((12,), (15,), (18,)),
             ...                            ((13,), (16,), (19,)),
             ...                            ((14,), (17,), (20,))))
             >>> print numerix.allequal(mesh._XZFaceIDs, XZFaceIDs) # doctest: +PROCESSOR_0
             True
-            
+
             >>> YZFaceIDs = numerix.array((((21,), (25,)),
             ...                            ((22,), (26,)),
             ...                            ((23,), (27,)),
@@ -571,7 +571,7 @@ class UniformGrid3D(UniformGrid):
             >>> print numerix.allequal(mesh._YZFaceIDs, YZFaceIDs) # doctest: +PROCESSOR_0
             True
 
-            >>> adjacentCellIDs = (numerix.array([0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 0, 1, 2, 3, 4, 5, 0, 0, 1, 2, 3, 3, 4, 5]), 
+            >>> adjacentCellIDs = (numerix.array([0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 0, 1, 2, 3, 4, 5, 0, 0, 1, 2, 3, 3, 4, 5]),
             ...                    numerix.array([0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 3, 4, 5, 0, 1, 2, 2, 3, 4, 5, 5]))
             >>> print numerix.allequal(mesh._adjacentCellIDs, adjacentCellIDs) # doctest: +PROCESSOR_0
             True
@@ -580,14 +580,14 @@ class UniformGrid3D(UniformGrid):
             ...                           (0., 0., 0., 0., 1., 1., 1., 1., 2., 2., 2., 2., 0., 0., 0., 0., 1., 1., 1., 1., 2., 2., 2., 2.),
             ...                           (0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.)))
             >>> vertices *= numerix.array([[dx], [dy], [dz]])
-            
+
             >>> print numerix.allequal(vertices, mesh.vertexCoords) # doctest: +PROCESSOR_0
             True
-        
+
             >>> faces = numerix.array((( 0,  1,  2,  4,  5,  6, 12, 13, 14, 16, 17, 18,  0,  1,  2,  4,  5,  6,  8,  9, 10,  0,  1,  2,  3,  4,  5,  6,  7),
             ...                        ( 1,  2,  3,  5,  6,  7, 13, 14, 15, 17, 18, 19,  1,  2,  3,  5,  6,  7,  9, 10, 11,  4,  5,  6,  7,  8,  9, 10, 11),
             ...                        ( 5,  6,  7,  9, 10, 11, 17, 18, 19, 21, 22, 23, 13, 14, 15, 17, 18, 19, 21, 22, 23, 16, 17, 18, 19, 20, 21, 22, 23),
-            ...                        ( 4,  5,  6,  8,  9, 10, 16, 17, 18, 20, 21, 22, 12, 13, 14, 16, 17, 18, 20, 21, 22, 12, 13, 14, 15, 16, 17, 18, 19))) 
+            ...                        ( 4,  5,  6,  8,  9, 10, 16, 17, 18, 20, 21, 22, 12, 13, 14, 16, 17, 18, 20, 21, 22, 12, 13, 14, 15, 16, 17, 18, 19)))
             >>> print numerix.allclose(faces, mesh.faceVertexIDs) # doctest: +PROCESSOR_0
             True
 
@@ -601,21 +601,21 @@ class UniformGrid3D(UniformGrid):
             True
 
             >>> externalFaces = numerix.array((0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 18, 19, 20, 21, 24, 25, 28))
-            >>> print numerix.allequal(externalFaces, 
+            >>> print numerix.allequal(externalFaces,
             ...                        numerix.nonzero(mesh.exteriorFaces)) # doctest: +PROCESSOR_0
             True
 
             >>> internalFaces = numerix.array((15, 16, 17, 22, 23, 26, 27))
-            >>> print numerix.allequal(internalFaces, 
+            >>> print numerix.allequal(internalFaces,
             ...                        numerix.nonzero(mesh.interiorFaces)) # doctest: +PROCESSOR_0
             True
 
             >>> from fipy.tools.numerix import MA
             >>> faceCellIds = MA.masked_values((( 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 0, 1, 2, 3, 4, 5, 0, 0, 1, 2, 3, 3, 4, 5),
-            ...                                 (-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 3, 4, 5,-1,-1,-1,-1, 1, 2,-1,-1, 4, 5,-1)), -1) 
+            ...                                 (-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 3, 4, 5,-1,-1,-1,-1, 1, 2,-1,-1, 4, 5,-1)), -1)
             >>> print numerix.allequal(faceCellIds, mesh.faceCellIDs) # doctest: +PROCESSOR_0
             True
-            
+
             >>> xy = dx * dy
             >>> xz = dx * dz
             >>> yz = dy * dz
@@ -624,7 +624,7 @@ class UniformGrid3D(UniformGrid):
             ...                            yz, yz, yz, yz, yz, yz, yz, yz))
             >>> print numerix.allclose(faceAreas, mesh._faceAreas, atol = 1e-10, rtol = 1e-10) # doctest: +PROCESSOR_0
             1
-            
+
             >>> faceCoords = numerix.take(vertices, faces, axis=1)
             >>> faceCenters = (faceCoords[...,0,:] + faceCoords[...,1,:] + faceCoords[...,2,:] + faceCoords[...,3,:]) / 4.
             >>> print numerix.allclose(faceCenters, mesh.faceCenters, atol = 1e-10, rtol = 1e-10)
@@ -644,7 +644,7 @@ class UniformGrid3D(UniformGrid):
             ...                                         ( 1, 1, 1, 1, 1, 1)))
             >>> print numerix.allequal(cellToFaceOrientations, mesh._cellToFaceOrientations) # doctest: +PROCESSOR_0
             True
-                                             
+
             >>> cellVolumes = numerix.array((dx*dy*dz, dx*dy*dz, dx*dy*dz, dx*dy*dz, dx*dy*dz, dx*dy*dz))
             >>> print numerix.allclose(cellVolumes, mesh.cellVolumes, atol = 1e-10, rtol = 1e-10) # doctest: +PROCESSOR_0
             True
@@ -654,13 +654,13 @@ class UniformGrid3D(UniformGrid):
             ...                              (   dz/2.,    dz/2.,    dz/2.,   dz/2.,    dz/2.,    dz/2.)))
             >>> print numerix.allclose(cellCenters, mesh.cellCenters, atol = 1e-10, rtol = 1e-10)
             True
-                                              
+
             >>> cellDistances = numerix.array((dz/2, dz/2, dz/2, dz/2, dz/2, dz/2, dz/2, dz/2, dz/2, dz/2, dz/2, dz/2,
             ...                                dy/2, dy/2, dy/2, dy, dy, dy, dy/2, dy/2, dy/2,
             ...                                dx/2, dx, dx, dx/2, dx/2, dx, dx, dx/2))
             >>> print numerix.allclose(cellDistances, mesh._cellDistances, atol = 1e-10, rtol = 1e-10) # doctest: +PROCESSOR_0
             True
-            
+
             >>> faceToCellDistances = MA.masked_values(((dz/2, dz/2, dz/2, dz/2, dz/2, dz/2, dz/2, dz/2, dz/2, dz/2, dz/2, dz/2, dy/2, dy/2, dy/2, dy/2, dy/2, dy/2, dy/2, dy/2, dy/2, dx/2, dx/2, dx/2, dx/2, dx/2, dx/2, dx/2, dx/2),
             ...                                         (  -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1, dy/2, dy/2, dy/2,   -1,   -1,   -1,   -1, dx/2, dx/2,   -1,   -1, dx/2, dx/2,   -1)), -1)
             >>> faceToCellDistanceRatios = faceToCellDistances[0] / cellDistances
@@ -700,7 +700,7 @@ class UniformGrid3D(UniformGrid):
             ...                                      [0, 1, 2, 3, 4, 5]])
             >>> print numerix.allequal(mesh._cellToCellIDsFilled, cellToCellIDsFilled) # doctest: +PROCESSOR_0
             True
-              
+
             >>> cellToCellDistances = numerix.take(cellDistances, cells)
             >>> print numerix.allclose(cellToCellDistances, mesh._cellToCellDistances, atol = 1e-10, rtol = 1e-10) # doctest: +PROCESSOR_0
             True
@@ -754,19 +754,19 @@ class UniformGrid3D(UniformGrid):
             >>> print numerix.allclose(mesh._cellVertexIDs, cellVertexIDs) # doctest: +PROCESSOR_0
             True
 
-            >>> from fipy.tools import dump            
-            >>> (f, filename) = dump.write(mesh, extension = '.gz')            
+            >>> from fipy.tools import dump
+            >>> (f, filename) = dump.write(mesh, extension = '.gz')
             >>> unpickledMesh = dump.read(filename, f)
 
             >>> print numerix.allequal(mesh.cellCenters, unpickledMesh.cellCenters)
             True
-            
+
             # Bug #130 & #135 are because we only checked a mesh with nz of 1
-            
+
             >>> nx = 1
             >>> ny = 2
             >>> nz = 3
-            
+
             >>> mesh = UniformGrid3D(nx=nx, ny=ny, nz=nz, dx=dx, dy=dy, dz=dz)
 
             >>> cellVertexIDs = numerix.array((9, 8, 7, 6, 3, 2, 1, 0))
@@ -775,11 +775,11 @@ class UniformGrid3D(UniformGrid):
             >>> cellVertexIDs = cellVertexIDs.swapaxes(0,1)
             >>> print numerix.allclose(mesh._cellVertexIDs, cellVertexIDs) # doctest: +PROCESSOR_0
             1
-            
+
             >>> nx = 3
             >>> ny = 1
             >>> nz = 2
-            
+
             >>> mesh = UniformGrid3D(nx=nx, ny=ny, nz=nz, dx=dx, dy=dy, dz=dz)
 
             >>> cellVertexIDs = numerix.array((13, 12, 9, 8, 5, 4, 1, 0))


### PR DESCRIPTION
This version makes all 195 tests in `examples/test.py` with NumPy 1.10 pass. All tests passed with NumPy 1.9.2 before the changes and still do with this version.

**Note**: There are a bunch white space changes due removed trailing white spaces. My editor is setup to remove them when saving a file. Diffing with `git diff -w` ignores these.