### PR TITLE
Remove incorrect `axis` argument to `concatenate`

### DIFF
--- a/fipy/meshes/uniformGrid1D.py
+++ b/fipy/meshes/uniformGrid1D.py
@@ -248,6 +248,11 @@ class UniformGrid1D(UniformGrid):
 
     @property
     def _faceToCellDistanceRatio(self):
+        """how far face is from first to second cell
+        
+        distance from center of face to center of first cell divided by distance
+        between cell centers
+        """
         distances = numerix.ones(self.numberOfFaces, 'd')
         distances *= 0.5
         if len(distances) > 0:

--- a/fipy/meshes/uniformGrid2D.py
+++ b/fipy/meshes/uniformGrid2D.py
@@ -344,6 +344,11 @@ class UniformGrid2D(UniformGrid):
 
     @property
     def _faceToCellDistanceRatio(self):
+        """how far face is from first to second cell
+        
+        distance from center of face to center of first cell divided by distance
+        between cell centers
+        """
         faceToCellDistanceRatios = numerix.zeros(self.numberOfFaces, 'd')
         faceToCellDistanceRatios[:] = 0.5
         faceToCellDistanceRatios[:self.nx] = 1.

--- a/fipy/meshes/uniformGrid3D.py
+++ b/fipy/meshes/uniformGrid3D.py
@@ -258,6 +258,11 @@ class UniformGrid3D(UniformGrid):
 
     @property
     def _faceToCellDistanceRatio(self):
+        """how far face is from first to second cell
+        
+        distance from center of face to center of first cell divided by distance
+        between cell centers
+        """
         XYdis = numerix.zeros((self.nx, self.ny, self.nz + 1),'d')
         XYdis[:] = 0.5
         XYdis[..., 0] = 1
@@ -275,7 +280,7 @@ class UniformGrid3D(UniformGrid):
         
         return numerix.concatenate((numerix.ravel(XYdis.swapaxes(0,2)),
                                     numerix.ravel(XZdis.swapaxes(0,2)),
-                                    numerix.ravel(YZdis.swapaxes(0,2))), axis=1)
+                                    numerix.ravel(YZdis.swapaxes(0,2))))
     
     @property
     def _orientedFaceNormals(self):


### PR DESCRIPTION
This never should have worked, but numpy 1.10 actually checks.
Also provide some documentation for what `_faceToCellDistanceRatio` is and
why it's scalar.

Addresses #475