### PR TITLE
restore trailing whitespace to expected output of pysparse matrix tests

### DIFF
--- a/fipy/matrices/pysparseMatrix.py
+++ b/fipy/matrices/pysparseMatrix.py
@@ -82,14 +82,14 @@ class _PysparseMatrix(_SparseMatrix):
             >>> L = _PysparseMatrixFromShape(rows=3, cols=3)
             >>> L.put([3.,10.,numerix.pi,2.5], [0,0,1,2], [2,1,1,0])
             >>> print L + _PysparseIdentityMatrix(size=3)
-             1.000000  10.000000   3.000000
-                ---     4.141593      ---
-             2.500000      ---     1.000000
+             1.000000  10.000000   3.000000  
+                ---     4.141593      ---    
+             2.500000      ---     1.000000  
 
             >>> print L + 0
-                ---    10.000000   3.000000
-                ---     3.141593      ---
-             2.500000      ---        ---
+                ---    10.000000   3.000000  
+                ---     3.141593      ---    
+             2.500000      ---        ---    
 
             >>> print L + 3
             Traceback (most recent call last):
@@ -191,9 +191,9 @@ class _PysparseMatrix(_SparseMatrix):
             >>> L = _PysparseMatrixFromShape(rows=3, cols=3)
             >>> L.put([3.,10.,numerix.pi,2.5], [0,0,1,2], [2,1,1,0])
             >>> print L
-                ---    10.000000   3.000000
-                ---     3.141593      ---
-             2.500000      ---        ---
+                ---    10.000000   3.000000  
+                ---     3.141593      ---    
+             2.500000      ---        ---    
         """
         self.matrix.put(vector, id1, id2)
 
@@ -204,14 +204,14 @@ class _PysparseMatrix(_SparseMatrix):
             >>> L = _PysparseMatrixFromShape(rows=3, cols=3)
             >>> L.putDiagonal([3.,10.,numerix.pi])
             >>> print L
-             3.000000      ---        ---
-                ---    10.000000      ---
-                ---        ---     3.141593
+             3.000000      ---        ---    
+                ---    10.000000      ---    
+                ---        ---     3.141593  
             >>> L.putDiagonal([10.,3.])
             >>> print L
-            10.000000      ---        ---
-                ---     3.000000      ---
-                ---        ---     3.141593
+            10.000000      ---        ---    
+                ---     3.000000      ---    
+                ---        ---     3.141593  
         """
         if type(vector) in [type(1), type(1.)]:
             ids = numerix.arange(self._shape[0])
@@ -239,9 +239,9 @@ class _PysparseMatrix(_SparseMatrix):
             >>> L.put([3.,10.,numerix.pi,2.5], [0,0,1,2], [2,1,1,0])
             >>> L.addAt([1.73,2.2,8.4,3.9,1.23], [1,2,0,0,1], [2,2,0,0,2])
             >>> print L
-            12.300000  10.000000   3.000000
-                ---     3.141593   2.960000
-             2.500000      ---     2.200000
+            12.300000  10.000000   3.000000  
+                ---     3.141593   2.960000  
+             2.500000      ---     2.200000  
         """
         self.matrix.update_add_at(vector, id1, id2)
 
@@ -404,9 +404,9 @@ class _PysparseIdentityMatrix(_PysparseMatrixFromShape):
         """Create a sparse matrix with '1' in the diagonal
 
             >>> print _PysparseIdentityMatrix(size=3)
-             1.000000      ---        ---
-                ---     1.000000      ---
-                ---        ---     1.000000
+             1.000000      ---        ---    
+                ---     1.000000      ---    
+                ---        ---     1.000000  
         """
         _PysparseMatrixFromShape.__init__(self, rows=size, cols=size, bandwidth = 1)
         ids = numerix.arange(size)
@@ -420,9 +420,9 @@ class _PysparseIdentityMeshMatrix(_PysparseIdentityMatrix):
             >>> from fipy.tools import serialComm
             >>> mesh = Grid1D(nx=3, communicator=serialComm)
             >>> print _PysparseIdentityMeshMatrix(mesh=mesh)
-             1.000000      ---        ---
-                ---     1.000000      ---
-                ---        ---     1.000000
+             1.000000      ---        ---    
+                ---     1.000000      ---    
+                ---        ---     1.000000  
         """
         _PysparseIdentityMatrix.__init__(self, size=mesh.numberOfCells)
 

--- a/fipy/matrices/scipyMatrix.py
+++ b/fipy/matrices/scipyMatrix.py
@@ -96,14 +96,14 @@ class _ScipyMatrix(_SparseMatrix):
             >>> L = _ScipyMatrixFromShape(size=3)
             >>> L.put([3.,10.,numerix.pi,2.5], [0,0,1,2], [2,1,1,0])
             >>> print L + _ScipyIdentityMatrix(size=3)
-             1.000000  10.000000   3.000000
-                ---     4.141593      ---
-             2.500000      ---     1.000000
+             1.000000  10.000000   3.000000  
+                ---     4.141593      ---    
+             2.500000      ---     1.000000  
 
             >>> print L + 0
-                ---    10.000000   3.000000
-                ---     3.141593      ---
-             2.500000      ---        ---
+                ---    10.000000   3.000000  
+                ---     3.141593      ---    
+             2.500000      ---        ---    
 
             >>> print L + 3
             Traceback (most recent call last):
@@ -199,9 +199,9 @@ class _ScipyMatrix(_SparseMatrix):
             >>> L = _ScipyMatrixFromShape(size=3)
             >>> L.put([3.,10.,numerix.pi,2.5], [0,0,1,2], [2,1,1,0])
             >>> print L
-                ---    10.000000   3.000000
-                ---     3.141593      ---
-             2.500000      ---        ---
+                ---    10.000000   3.000000  
+                ---     3.141593      ---    
+             2.500000      ---        ---    
         """
         assert(len(id1) == len(id2) == len(vector))
 
@@ -218,14 +218,14 @@ class _ScipyMatrix(_SparseMatrix):
             >>> L = _ScipyMatrixFromShape(size=3)
             >>> L.putDiagonal([3.,10.,numerix.pi])
             >>> print L
-             3.000000      ---        ---
-                ---    10.000000      ---
-                ---        ---     3.141593
+             3.000000      ---        ---    
+                ---    10.000000      ---    
+                ---        ---     3.141593  
             >>> L.putDiagonal([10.,3.])
             >>> print L
-            10.000000      ---        ---
-                ---     3.000000      ---
-                ---        ---     3.141593
+            10.000000      ---        ---    
+                ---     3.000000      ---    
+                ---        ---     3.141593  
         """
         if type(vector) in [int, float]:
             vector = numerix.repeat(vector, self._shape[0])
@@ -246,9 +246,9 @@ class _ScipyMatrix(_SparseMatrix):
             >>> L.put([3.,10.,numerix.pi,2.5], [0,0,1,2], [2,1,1,0])
             >>> L.addAt([1.73,2.2,8.4,3.9,1.23], [1,2,0,0,1], [2,2,0,0,2])
             >>> print L
-            12.300000  10.000000   3.000000
-                ---     3.141593   2.960000
-             2.500000      ---     2.200000
+            12.300000  10.000000   3.000000  
+                ---     3.141593   2.960000  
+             2.500000      ---     2.200000  
         """
         assert(len(id1) == len(id2) == len(vector))
 
@@ -393,9 +393,9 @@ class _ScipyIdentityMatrix(_ScipyMatrixFromShape):
         Create a sparse matrix with '1' in the diagonal
 
             >>> print _ScipyIdentityMatrix(size=3)
-             1.000000      ---        ---
-                ---     1.000000      ---
-                ---        ---     1.000000
+             1.000000      ---        ---    
+                ---     1.000000      ---    
+                ---        ---     1.000000  
         """
         _ScipyMatrixFromShape.__init__(self, size=size, bandwidth = 1)
         ids = numerix.arange(size)
@@ -410,9 +410,9 @@ class _ScipyIdentityMeshMatrix(_ScipyIdentityMatrix):
             >>> from fipy.tools import serialComm
             >>> mesh = Grid1D(nx=3, communicator=serialComm)
             >>> print _ScipyIdentityMeshMatrix(mesh=mesh)
-             1.000000      ---        ---
-                ---     1.000000      ---
-                ---        ---     1.000000
+             1.000000      ---        ---    
+                ---     1.000000      ---    
+                ---        ---     1.000000  
         """
         _ScipyIdentityMatrix.__init__(self, size=mesh.numberOfCells)
 

--- a/fipy/matrices/trilinosMatrix.py
+++ b/fipy/matrices/trilinosMatrix.py
@@ -192,14 +192,14 @@ class _TrilinosMatrix(_SparseMatrix):
             >>> L.addAt((3.,10.,numerix.pi,2.5), (0,0,1,2), (2,1,1,0))
             >>> L.addAt([0,0,0], [0,1,2], [0,1,2])
             >>> print L + _TrilinosIdentityMatrix(size=3)
-             1.000000  10.000000   3.000000
-                ---     4.141593      ---
-             2.500000      ---     1.000000
+             1.000000  10.000000   3.000000  
+                ---     4.141593      ---    
+             2.500000      ---     1.000000  
 
             >>> print L + 0
-                ---    10.000000   3.000000
-                ---     3.141593      ---
-             2.500000      ---        ---
+                ---    10.000000   3.000000  
+                ---     3.141593      ---    
+             2.500000      ---        ---    
 
             >>> print L + 3
             Traceback (most recent call last):
@@ -309,9 +309,9 @@ class _TrilinosMatrix(_SparseMatrix):
             >>> L = _TrilinosMatrixFromShape(rows=3, cols=3)
             >>> L.put((3.,10.,numerix.pi,2.5), (0,0,1,2), (2,1,1,0))
             >>> print L
-                ---    10.000000   3.000000
-                ---     3.141593      ---
-             2.500000      ---        ---
+                ---    10.000000   3.000000  
+                ---     3.141593      ---    
+             2.500000      ---        ---    
         """
 
         if hasattr(id1, 'dtype') and id1.dtype.name == 'int64':
@@ -371,14 +371,14 @@ class _TrilinosMatrix(_SparseMatrix):
             >>> L = _TrilinosMatrixFromShape(rows=3, cols=3)
             >>> L.putDiagonal((3.,10.,numerix.pi))
             >>> print L
-             3.000000      ---        ---
-                ---    10.000000      ---
-                ---        ---     3.141593
+             3.000000      ---        ---    
+                ---    10.000000      ---    
+                ---        ---     3.141593  
             >>> L.putDiagonal((10.,3.))
             >>> print L
-            10.000000      ---        ---
-                ---     3.000000      ---
-                ---        ---     3.141593
+            10.000000      ---        ---    
+                ---     3.000000      ---    
+                ---        ---     3.141593  
         """
 
 
@@ -417,9 +417,9 @@ class _TrilinosMatrix(_SparseMatrix):
             >>> L.addAt((3.,10.,numerix.pi,2.5), (0,0,1,2), (2,1,1,0))
             >>> L.addAt((1.73,2.2,8.4,3.9,1.23), (1,2,0,0,1), (2,2,0,0,2))
             >>> print L
-            12.300000  10.000000   3.000000
-                ---     3.141593   2.960000
-             2.500000      ---     2.200000
+            12.300000  10.000000   3.000000  
+                ---     3.141593   2.960000  
+             2.500000      ---     2.200000  
         """
 
         ## This was added as it seems that trilinos does not like int64 arrays
@@ -1299,9 +1299,9 @@ class _TrilinosIdentityMatrix(_TrilinosMatrixFromShape):
         Create a sparse matrix with '1' in the diagonal
 
             >>> print _TrilinosIdentityMatrix(size=3)
-             1.000000      ---        ---
-                ---     1.000000      ---
-                ---        ---     1.000000
+             1.000000      ---        ---    
+                ---     1.000000      ---    
+                ---        ---     1.000000  
         """
         _TrilinosMatrixFromShape.__init__(self, rows=size, cols=size, bandwidth=1)
         ids = numerix.arange(size)
@@ -1315,9 +1315,9 @@ class _TrilinosIdentityMeshMatrix(_TrilinosMeshMatrix):
             >>> from fipy import Grid1D
             >>> mesh = Grid1D(nx=3)
             >>> print _TrilinosIdentityMeshMatrix(mesh=mesh)
-             1.000000      ---        ---
-                ---     1.000000      ---
-                ---        ---     1.000000
+             1.000000      ---        ---    
+                ---     1.000000      ---    
+                ---        ---     1.000000  
         """
         _TrilinosMeshMatrix.__init__(self, mesh=mesh, bandwidth=1)
         size = mesh.numberOfCells


### PR DESCRIPTION
Fixes #484.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/usnistgov/fipy/485)
<!-- Reviewable:end -->
