### PR TITLE
Remove drop_tol argument to scipy.sparse.linalg.splu

### DIFF
--- a/fipy/solvers/scipy/linearLUSolver.py
+++ b/fipy/solvers/scipy/linearLUSolver.py
@@ -58,7 +58,6 @@ class LinearLUSolver(_ScipySolver):
         b = b * (1 / maxdiag)
 
         LU = splu(L.matrix.asformat("csc"), diag_pivot_thresh=1.,
-                                            drop_tol=0.,
                                             relax=1,
                                             panel_size=10,
                                             permc_spec=3)


### PR DESCRIPTION
This argument was deprecated and then removed ca. scipy 0.19.1

https://docs.scipy.org/doc/scipy-0.19.1/reference/generated/generated/scipy.sparse.linalg.splu.html

Fixes #531