### PR TITLE
add Codacy badge

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,3 @@
+---
+exclude_paths:
+  - documentation/_themes/**

--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,9 @@ Overview
 
 .. only:: html
 
-   |GitHub|_ |TravisCI|_ |gitter|_ |PyPi|_
+   |GitHub|_ |TravisCI|_ |PyPi|_  |Codacy|_
    
-   |Depsy|_ |OpenHub|_ |CondaForge|_
+   |gitter|_ |Depsy|_ |OpenHub|_ |CondaForge|_
 
 The :term:`FiPy` framework includes terms for transient diffusion,
 convection and standard sources, enabling the solution of arbitrary
@@ -253,3 +253,5 @@ or a
 .. _CondaForge:    https://anaconda.org/guyer/fipy
 .. |Depsy|         image:: http://depsy.org/api/package/pypi/FiPy/badge.svg
 .. _Depsy:         http://depsy.org/package/python/FiPy
+.. |Codacy|         image:: https://api.codacy.com/project/badge/Grade/d02921bb54b14e88a1e2e1f5520133f4
+.. _Codacy:         https://www.codacy.com/app/tkphd/fipy?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=usnistgov/fipy&amp;utm_campaign=Badge_Grade

--- a/README.rst
+++ b/README.rst
@@ -22,11 +22,9 @@ Overview
    significant advantage to :term:`Python` is the existing suite of tools for
    array calculations, sparse matrices and data rendering. 
 
-.. only:: html
-
-   |GitHub|_ |TravisCI|_ |PyPi|_  |Codacy|_
+|GitHub|_ |TravisCI|_ |PyPi|_  |Codacy|_
    
-   |gitter|_ |Depsy|_ |OpenHub|_ |CondaForge|_
+|gitter|_ |Depsy|_ |OpenHub|_ |CondaForge|_
 
 The :term:`FiPy` framework includes terms for transient diffusion,
 convection and standard sources, enabling the solution of arbitrary

--- a/documentation/_templates/index.html
+++ b/documentation/_templates/index.html
@@ -50,10 +50,11 @@
   <!-- Development & Quality Assurance Badges -->
   <a href="https://github.com/usnistgov/fipy"><img src="https://img.shields.io/github/contributors/usnistgov/fipy.svg" alt="GitHub"></img></a>
   <a href="https://travis-ci.org/usnistgov/fipy"><img src="https://travis-ci.org/usnistgov/fipy.svg?branch=develop" alt="TravisCI"></img></a>
-  <a href="https://gitter.im/usnistgov/fipy"><img src="https://badges.gitter.im/usnistgov/fipy.svg" alt="gitter"></img></a>
   <a href="https://pypi.python.org/pypi/FiPy"><img src="https://img.shields.io/pypi/v/fipy.svg" alt="PyPi"></img></a>
+  <a class="badge-align" href="https://www.codacy.com/app/tkphd/fipy?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=usnistgov/fipy&amp;utm_campaign=Badge_Grade"><img src="https://api.codacy.com/project/badge/Grade/d02921bb54b14e88a1e2e1f5520133f4"/></a>
   <br>
   <!-- Community Badges -->
+  <a href="https://gitter.im/usnistgov/fipy"><img src="https://badges.gitter.im/usnistgov/fipy.svg" alt="gitter"></img></a>
   <a href="http://depsy.org/package/python/FiPy"><img src="http://depsy.org/api/package/pypi/FiPy/badge.svg" alt="Depsy"></img></a>
   <a href="https://www.openhub.net/p/fipy"><img src="https://www.openhub.net/p/fipy/widgets/project_thin_badge.gif" alt="OpenHub"></img></a>
   <a href="https://anaconda.org/guyer/fipy"><img src="https://anaconda.org/guyer/fipy/badges/downloads.svg" alt="CondaForge"></img></a>


### PR DESCRIPTION
[Codacy][_code] is a static code analysis service with GitHub integration,
and has been helpful in streamlining the [HiPerC][_hipc] codebase. This
PR would add the Codacy badge to FiPy's online documentation.

At the time of this request, FiPy receives a [grade of C](https://app.codacy.com/project/tkphd/fipy/dashboard), due in large part to
the NIST website templates. The config file, `.codacy.yml`, is intended to mask
this received code from consideration, but it is untested.

<!--References-->
[_code]: https://www.codacy.com
[_hipc]: https://github.com/usnistgov/hiperc