### PR TITLE
Fix fipy.test doesn't work

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -80,6 +80,7 @@ install:
 build: off
 
 test_script:
+    - python setup.py egg_info
     - if !%FIPY_INLINE%==! python setup.py test 1> NUL 2>&1
     - python setup.py test
     - conda env export

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ commands:
           no_output_timeout: 30m
           command: |
             source activate ~/project/test-environment
+            python setup.py egg_info
             if [[ ! -z "${FIPY_INLINE}" ]]; then
               << parameters.mpirun >> python setup.py test > /dev/null 2>&1 || true;
             fi

--- a/documentation/USAGE.rst
+++ b/documentation/USAGE.rst
@@ -59,6 +59,14 @@ examples <part:examples>`. To run the test cases in both :ref:`modules
 
     $ python setup.py test
 
+.. note::
+
+   You may need to first run::
+
+        $ python setup.py egg_info
+
+   for this to work properly.
+
 in an unpacked :term:`FiPy` archive. The test suite can be run with a
 number of different configurations depending on which solver suite is
 available and other factors. See :ref:`FlagsAndEnvironmentVariables`

--- a/fipy/__init__.py
+++ b/fipy/__init__.py
@@ -142,8 +142,7 @@ def test(*args):
     """
 
     from setuptools import setup
-    from fipy.tests.testClass import _TestClass
-    from setuptools.command.test import test as _test
+    from fipy.tests.test import test
     import tempfile
 
     tmpDir = tempfile.mkdtemp()
@@ -152,7 +151,7 @@ def test(*args):
         setup(name='FiPy',
               script_args = ['egg_info', '--egg-base=' + tmpDir,
                              'test', '--modules'] + list(args),
-              cmdclass={'test': _TestClass(_test)})
+              cmdclass={'test': test})
     except SystemExit, exitErr:
         import shutil
         shutil.rmtree(tmpDir)

--- a/fipy/tests/test.py
+++ b/fipy/tests/test.py
@@ -1,252 +1,248 @@
 from setuptools.command.test import test as _test
 
-def _TestClass(base):
-    class _test(base):
-        description = str(base.description) + ", for FiPy and its examples"
+class test(_test):
+    description = str(_test.description) + ", for FiPy and its examples"
 
-        # List of option tuples: long name, short name (None if no short
-        # name), and help string.
-        user_options = base.user_options + [
-            ('inline', None, "run FiPy with inline compilation enabled"),
-            ('pythoncompiled=', None, "directory in which to put weave's work product"),
-            ('Trilinos', None, "run FiPy using Trilinos solvers"),
-            ('Pysparse', None, "run FiPy using Pysparse solvers (default)"),
-            ('trilinos', None, "run FiPy using Trilinos solvers"),
-            ('pysparse', None, "run FiPy using Pysparse solvers (default)"),
-            ('scipy', None, "run FiPy using SciPy solvers"),
-            ('Scipy', None, "run FiPy using SciPy solvers"),
-            ('no-pysparse',None, "run FiPy without using the Pysparse solvers"),
-            ('pyamg',None, "run FiPy without using the PyAMG solvers"),
-            ('pyamgx',None, "run FiPy using the pyamgx solvers"),
-            ('all', None, "run all non-interactive FiPy tests (default)"),
-            ('really-all', None, "run *all* FiPy tests (including those requiring user input)"),
-            ('examples', None, "test FiPy examples"),
-            ('modules', None, "test FiPy code modules"),
-            ('viewers', None, "test FiPy viewer modules (requires user input)"),
-            ('cache', None, "run FiPy with Variable caching"),
-            ('no-cache', None, "run FiPy without Variable caching"),
-            ('timetests=', None, "file in which to put time spent on each test"),
-            ('skfmm', None, "run FiPy using the Scikit-fmm level set solver (default)"),
-            ('lsmlib', None, "run FiPy using the LSMLIB level set solver (default)"),
-           ]
+    # List of option tuples: long name, short name (None if no short
+    # name), and help string.
+    user_options = _test.user_options + [
+        ('inline', None, "run FiPy with inline compilation enabled"),
+        ('pythoncompiled=', None, "directory in which to put weave's work product"),
+        ('Trilinos', None, "run FiPy using Trilinos solvers"),
+        ('Pysparse', None, "run FiPy using Pysparse solvers (default)"),
+        ('trilinos', None, "run FiPy using Trilinos solvers"),
+        ('pysparse', None, "run FiPy using Pysparse solvers (default)"),
+        ('scipy', None, "run FiPy using SciPy solvers"),
+        ('Scipy', None, "run FiPy using SciPy solvers"),
+        ('no-pysparse',None, "run FiPy without using the Pysparse solvers"),
+        ('pyamg',None, "run FiPy without using the PyAMG solvers"),
+        ('pyamgx',None, "run FiPy using the pyamgx solvers"),
+        ('all', None, "run all non-interactive FiPy tests (default)"),
+        ('really-all', None, "run *all* FiPy tests (including those requiring user input)"),
+        ('examples', None, "test FiPy examples"),
+        ('modules', None, "test FiPy code modules"),
+        ('viewers', None, "test FiPy viewer modules (requires user input)"),
+        ('cache', None, "run FiPy with Variable caching"),
+        ('no-cache', None, "run FiPy without Variable caching"),
+        ('timetests=', None, "file in which to put time spent on each test"),
+        ('skfmm', None, "run FiPy using the Scikit-fmm level set solver (default)"),
+        ('lsmlib', None, "run FiPy using the LSMLIB level set solver (default)"),
+       ]
 
 
-        def initialize_options(self):
-            base.initialize_options(self)
+    def initialize_options(self):
+        _test.initialize_options(self)
 
-            self.all = False
-            self.really_all = False
-            self.examples = False
-            self.modules = False
-            self.viewers = False
+        self.all = False
+        self.really_all = False
+        self.examples = False
+        self.modules = False
+        self.viewers = False
 
-            self.inline = False
-            self.pythoncompiled = None
-            self.cache = False
-            self.no_cache = True
-            self.Trilinos = False
-            self.Pysparse = False
-            self.trilinos = False
-            self.pysparse = False
-            self.no_pysparse = False
-            self.pyamg = False
-            self.pyamgx = False
-            self.scipy = False
-            self.timetests = None
-            self.skfmm = False
-            self.lsmlib = False
+        self.inline = False
+        self.pythoncompiled = None
+        self.cache = False
+        self.no_cache = True
+        self.Trilinos = False
+        self.Pysparse = False
+        self.trilinos = False
+        self.pysparse = False
+        self.no_pysparse = False
+        self.pyamg = False
+        self.pyamgx = False
+        self.scipy = False
+        self.timetests = None
+        self.skfmm = False
+        self.lsmlib = False
 
-        def finalize_options(self):
-            noSuiteOrModule = (self.test_suite is None
-                               and self.test_module is None)
+    def finalize_options(self):
+        noSuiteOrModule = (self.test_suite is None
+                           and self.test_module is None)
 
-            base.finalize_options(self)
+        _test.finalize_options(self)
 
-            if noSuiteOrModule:
-                # setuptools completely changed how it uses test_suite and test_args with v. 18.0
-                # we do our best to keep it confused
-                self.test_suite = None
-                
-            if not (self.examples or self.modules or self.viewers):
-                self.all = True
-            if self.all or self.really_all:
-                self.examples = True
-                self.modules = True
-            if self.really_all:
-                self.viewers = True
+        if noSuiteOrModule:
+            # setuptools completely changed how it uses test_suite and test_args with v. 18.0
+            # we do our best to keep it confused
+            self.test_suite = None
 
-            # If we drop setuptools < 18.0, the remaining lines can probably be removed
-            
-            self.test_args = list(self._test_args())
+        if not (self.examples or self.modules or self.viewers):
+            self.all = True
+        if self.all or self.really_all:
+            self.examples = True
+            self.modules = True
+        if self.really_all:
+            self.viewers = True
 
-            if noSuiteOrModule:
-                # setuptools completely changed how it uses test_suite and test_args with v. 18.0
-                # we do our best to keep it confused
-                self.test_suite = "dummy"
+        # If we drop setuptools < 18.0, the remaining lines can probably be removed
 
-        def _test_args(self):
-            # can't seem to delegate a generator until Python 3.3
-            
-            if self.verbose:
-                yield '--verbose'
-            if self.test_suite:
-                yield self.test_suite
-                
-            if self.viewers:
-                print "*" * 60
-                print "*" + "".center(58) + "*"
-                print "*" + "ATTENTION".center(58) + "*"
-                print "*" + "".center(58) + "*"
-                print "*" + "Some of the following tests require user interaction".center(58) + "*"
-                print "*" + "".center(58) + "*"
-                print "*" * 60
-                
-                yield "fipy.viewers.testinteractive._suite"
-            if self.modules:
-                yield "fipy.testFiPy._suite"
-            if self.examples:
-                yield "examples.test._suite"
+        self.test_args = list(self._test_args())
 
-        def printPackageInfo(self):
-            
-            for pkg in ['fipy', 'numpy', 'pysparse', 'scipy', 'matplotlib', 'mpi4py', 'pyamgx']:
+        if noSuiteOrModule:
+            # setuptools completely changed how it uses test_suite and test_args with v. 18.0
+            # we do our best to keep it confused
+            self.test_suite = "dummy"
 
-                try:
-                    mod = __import__(pkg)
+    def _test_args(self):
+        # can't seem to delegate a generator until Python 3.3
 
-                    if hasattr(mod, '__version__'):
-                        print pkg,'version',mod.__version__
-                    else:
-                        print pkg,'version not available'
+        if self.verbose:
+            yield '--verbose'
+        if self.test_suite:
+            yield self.test_suite
 
-                except ImportError, e:
-                    print pkg,'is not installed'
+        if self.viewers:
+            print "*" * 60
+            print "*" + "".center(58) + "*"
+            print "*" + "ATTENTION".center(58) + "*"
+            print "*" + "".center(58) + "*"
+            print "*" + "Some of the following tests require user interaction".center(58) + "*"
+            print "*" + "".center(58) + "*"
+            print "*" * 60
 
-                except Exception, e:
-                    print pkg, 'version check failed:', e
+            yield "fipy.viewers.testinteractive._suite"
+        if self.modules:
+            yield "fipy.testFiPy._suite"
+        if self.examples:
+            yield "examples.test._suite"
 
-            ## PyTrilinos
+    def printPackageInfo(self):
+
+        for pkg in ['fipy', 'numpy', 'pysparse', 'scipy', 'matplotlib', 'mpi4py', 'pyamgx']:
+
             try:
-                import PyTrilinos
-                print PyTrilinos.version()
-            except ImportError, e:
-                print 'PyTrilinos is not installed'
-            except Exception, e:
-                print 'PyTrilinos version check failed:', e
+                mod = __import__(pkg)
 
-            ## Mayavi uses a non-standard approach for storing its version number.
-            try:
-                from mayavi.__version__ import __version__ as mayaviversion
-                print 'mayavi version', mayaviversion
-            except ImportError, e:
-                try:
-                    from enthought.mayavi.__version__ import __version__ as mayaviversion
-                    print 'enthought.mayavi version', mayaviversion
-                except ImportError, e:
-                    print 'enthought.mayavi is not installed'
-                except Exception, e:
-                    print 'enthought.mayavi version check failed:', e
-            except Exception, e:
-                print 'mayavi version check failed:', e
-
-            ## Gmsh version
-            try:
-                from fipy.meshes.gmshMesh import gmshVersion
-                gmshversion = gmshVersion()
-                if gmshversion is None:
-                    print 'gmsh is not installed'
+                if hasattr(mod, '__version__'):
+                    print pkg,'version',mod.__version__
                 else:
-                    print 'gmsh version',gmshversion
+                    print pkg,'version not available'
+
+            except ImportError, e:
+                print pkg,'is not installed'
+
             except Exception, e:
-                print 'gmsh version check failed:', e
+                print pkg, 'version check failed:', e
 
-        def run_tests(self):
-            import sys
-            if self.Trilinos or self.trilinos or self.no_pysparse:
-                try:
-                    ## The import scipy statement is added to allow
-                    ## the --Trilinos tests to run without throwing a
-                    ## segmentation fault. This is caused by weird
-                    ## behavior in scipy and PyTrilinos depending on
-                    ## the order in which modules are imported
-                    try:
-                        import scipy
-                    except:
-                        pass
-                    import PyTrilinos
-                except ImportError, a:
-                    print >>sys.stderr, "!!! Trilinos library is not installed"
-                    return
+        ## PyTrilinos
+        try:
+            import PyTrilinos
+            print PyTrilinos.version()
+        except ImportError, e:
+            print 'PyTrilinos is not installed'
+        except Exception, e:
+            print 'PyTrilinos version check failed:', e
 
-            if self.pyamgx:
-                try:
-                    ## Unregister the function pyamgx.finalize
-                    ## from atexit. This prevents
-                    ## pyamgx from printing an error message
-                    ## about memory leaks and a dump of leaked memory.
-                    ## The memory leaks happen because
-                    ## the tests do not use the pyamgx solvers
-                    ## "cleanly", i.e., they do not use the
-                    ## `with` statement.
-                    import pyamgx
-                    import atexit
-                    if hasattr(atexit, 'unregister'):
-                        atexit.unregister(pyamgx.finalize)
-                    else:
-                        atexit._exithandlers.remove(
-                            (pyamgx.finalize, (), {}))
-                except ImportError, e:
-                    print >>sys.stederr, "!!! pyamgx package is not installed"
-                    return
-
-            if self.inline:
-                try:
-                    import weave
-                except ImportError, a:
-                    print >>sys.stderr, "!!! weave library is not installed"
-                    return
-
-            if self.pythoncompiled is not None:
-                import os
-                os.environ['PYTHONCOMPILED'] = self.pythoncompiled
-
-            self.printPackageInfo()
-
-            from pkg_resources import EntryPoint
-            import unittest
-            loader_ep = EntryPoint.parse("x="+self.test_loader)
-            loader_class = loader_ep.load(require=False)
-
-            from fipy.tools import numerix
-            printoptions = numerix.get_printoptions()
-            if "legacy" in printoptions:
-                numerix.set_printoptions(legacy="1.13")
-
+        ## Mayavi uses a non-standard approach for storing its version number.
+        try:
+            from mayavi.__version__ import __version__ as mayaviversion
+            print 'mayavi version', mayaviversion
+        except ImportError, e:
             try:
-                unittest.main(
-                    None, None, [unittest.__file__]+self.test_args,
-                    testLoader = loader_class()
-                    )
-            except SystemExit, exitErr:
-                # unittest.main(..., exit=...) not available until Python 2.7
-                from fipy.tests.doctestPlus import report_skips
-                report_skips()
-                if self.timetests is not None:
+                from enthought.mayavi.__version__ import __version__ as mayaviversion
+                print 'enthought.mayavi version', mayaviversion
+            except ImportError, e:
+                print 'enthought.mayavi is not installed'
+            except Exception, e:
+                print 'enthought.mayavi version check failed:', e
+        except Exception, e:
+            print 'mayavi version check failed:', e
+
+        ## Gmsh version
+        try:
+            from fipy.meshes.gmshMesh import gmshVersion
+            gmshversion = gmshVersion()
+            if gmshversion is None:
+                print 'gmsh is not installed'
+            else:
+                print 'gmsh version',gmshversion
+        except Exception, e:
+            print 'gmsh version check failed:', e
+
+    def run_tests(self):
+        import sys
+        if self.Trilinos or self.trilinos or self.no_pysparse:
+            try:
+                ## The import scipy statement is added to allow
+                ## the --Trilinos tests to run without throwing a
+                ## segmentation fault. This is caused by weird
+                ## behavior in scipy and PyTrilinos depending on
+                ## the order in which modules are imported
+                try:
+                    import scipy
+                except:
                     pass
+                import PyTrilinos
+            except ImportError, a:
+                print >>sys.stderr, "!!! Trilinos library is not installed"
+                return
+
+        if self.pyamgx:
+            try:
+                ## Unregister the function pyamgx.finalize
+                ## from atexit. This prevents
+                ## pyamgx from printing an error message
+                ## about memory leaks and a dump of leaked memory.
+                ## The memory leaks happen because
+                ## the tests do not use the pyamgx solvers
+                ## "cleanly", i.e., they do not use the
+                ## `with` statement.
+                import pyamgx
+                import atexit
+                if hasattr(atexit, 'unregister'):
+                    atexit.unregister(pyamgx.finalize)
                 else:
-                    raise
+                    atexit._exithandlers.remove(
+                        (pyamgx.finalize, (), {}))
+            except ImportError, e:
+                print >>sys.stederr, "!!! pyamgx package is not installed"
+                return
 
-            if "legacy" in printoptions:
-                numerix.set_printoptions(legacy=printoptions["legacy"])
+        if self.inline:
+            try:
+                import weave
+            except ImportError, a:
+                print >>sys.stderr, "!!! weave library is not installed"
+                return
 
+        if self.pythoncompiled is not None:
+            import os
+            os.environ['PYTHONCOMPILED'] = self.pythoncompiled
+
+        self.printPackageInfo()
+
+        from pkg_resources import EntryPoint
+        import unittest
+        loader_ep = EntryPoint.parse("x="+self.test_loader)
+        loader_class = loader_ep.load(require=False)
+
+        from fipy.tools import numerix
+        printoptions = numerix.get_printoptions()
+        if "legacy" in printoptions:
+            numerix.set_printoptions(legacy="1.13")
+
+        try:
+            unittest.main(
+                None, None, [unittest.__file__]+self.test_args,
+                testLoader = loader_class()
+                )
+        except SystemExit, exitErr:
+            # unittest.main(..., exit=...) not available until Python 2.7
+            from fipy.tests.doctestPlus import report_skips
+            report_skips()
             if self.timetests is not None:
-                from fipy.tests.doctestPlus import _DocTestTimes
-                import numpy
-                _DocTestTimes = numpy.rec.fromrecords(_DocTestTimes, formats='f8,S255', names='time,test')
-                _DocTestTimes.sort(order=('time', 'test'))
-                numpy.savetxt(self.timetests, _DocTestTimes[::-1], fmt="%8.4f\t%s")
+                pass
+            else:
+                raise
 
-            raise exitErr
-    return _test
+        if "legacy" in printoptions:
+            numerix.set_printoptions(legacy=printoptions["legacy"])
 
-test = _TestClass(_test)
+        if self.timetests is not None:
+            from fipy.tests.doctestPlus import _DocTestTimes
+            import numpy
+            _DocTestTimes = numpy.rec.fromrecords(_DocTestTimes, formats='f8,S255', names='time,test')
+            _DocTestTimes.sort(order=('time', 'test'))
+            numpy.savetxt(self.timetests, _DocTestTimes[::-1], fmt="%8.4f\t%s")
+
+        raise exitErr

--- a/fipy/tests/test.py
+++ b/fipy/tests/test.py
@@ -1,3 +1,5 @@
+from setuptools.command.test import test as _test
+
 def _TestClass(base):
     class _test(base):
         description = str(base.description) + ", for FiPy and its examples"
@@ -246,3 +248,5 @@ def _TestClass(base):
 
             raise exitErr
     return _test
+
+test = _TestClass(_test)

--- a/setup.py
+++ b/setup.py
@@ -8,23 +8,18 @@ Standards and Technology (NIST).
 """
 
 from setuptools import setup, find_packages
-from setuptools.command.test import test as _test
 
 import versioneer
 
 from _setup.build_docs import build_docs
 from _setup.changelog import changelog
 from _setup.copy_script import copy_script
-from _setup.testClass import _TestClass
 from _setup.upload_products import upload_products
 
 # bootstrap setuptools for users that don't already have it
 import ez_setup
 
 ez_setup.use_setuptools()
-
-TEST = _TestClass(_test)
-
 
 try:
     FILE = open("README.rst", "r")
@@ -54,8 +49,6 @@ DIST = setup(
         {
             "build_docs": build_docs,
             "upload_products": upload_products,
-            "test": TEST,
-            "unittest": TEST,
             "copy_script": copy_script,
             "changelog": changelog,
         },
@@ -67,6 +60,9 @@ DIST = setup(
                  [fipy.viewers]
                  matplotlib = fipy.viewers.matplotlibViewer:MatplotlibViewer
                  mayavi = fipy.viewers.mayaviViewer:MayaviClient
+                 [distutils.commands]
+                 test = fipy.tests.test:test
+                 unittest = fipy.tests.test:test
              """,
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Move `test` command back  inside `fipy` namespace to enable both `python setup.py test`
*and* `python -c "import fipy; fipy.test()"`  to use the same code.
