### PR TITLE
fix: use correct logo links

### DIFF
--- a/documentation/_themes/nist/layout.html
+++ b/documentation/_themes/nist/layout.html
@@ -22,7 +22,7 @@
         <div class="region region-utility">
   <div id="block-menu-menu-utility-navigation" class="block menu--utility-nav first last odd block--menu block--menu-menu-utility-navigation" role="navigation">
 
-    
+
   <ul class="menu"><li  class="menu__item is-leaf first leaf menu-depth-1"><a href="https://www.nist.gov/careers" class="menu__link">Careers</a></li>
 <li  class="menu__item is-leaf leaf menu-depth-1"><a href="https://www.nist.gov/shop" class="menu__link shop">Shop</a></li>
 <li  class="menu__item is-leaf last leaf menu-depth-1"><a href="https://www.nist.gov/about-nist/visit" class="menu__link">Visit</a></li>
@@ -36,7 +36,7 @@
 
     <div class="header__logo">
       <a href="https://www.nist.gov/" title="National Institute of Standards and Technology" class="header__logo-link" rel="home">
-                  <img src="https://www.nist.gov/sites/all/themes/nist_style/images/svg/nist_logo_reverse.svg" onerror="this.src='https://www.nist.gov/sites/all/themes/nist_style/images/build/nist_logo_reverse.png'" alt="National Institute of Standards and Technology" />
+        <img src="https://www.nist.gov/themes/custom/nist/dist/img/logo/logo.svg" alt="National Institute of Standards and Technology" />
       </a>
     </div>
 
@@ -82,7 +82,7 @@
         <div class="region region-navigation">
   <div id="block-menu-block-main-menu-mega" class="block menu--main-menu--new first last odd block--menu-block block--menu-block-main-menu-mega" role="navigation">
 
-    
+
 <div class="menu-block-wrapper menu-block-main_menu_mega menu-name-main-menu parent-mlid-0 menu-level-1">
 <ul class="menu"><li  class="menu__item is-expanded first expanded menu-mlid-33106 menu-depth-1"><a href="https://www.nist.gov/topics" class="menu__link">Topics <span class="expander"><svg class="icon icon-plus"><use xlink:href="#icon-plus"></use></svg><svg class="icon icon-minus"><use xlink:href="#icon-minus"></use></svg><span class="element-invisible">Expand or Collapse</span></span></a><div class="menu--main-menu--new__submenu"><ul class="menu"><li  class="menu__item is-leaf first leaf menu-mlid-32181 menu-depth-2"><a href="https://www.nist.gov/topics/advanced-communications" class="menu__link">Advanced Communications</a></li>
 <li  class="menu__item is-leaf leaf menu-mlid-135026 menu-depth-2"><a href="https://www.nist.gov/topics/artificial-intelligence" class="menu__link">Artificial Intelligence</a></li>
@@ -197,7 +197,7 @@
       <div class="page-info">
         <a id="main-content"></a>
       </div>
-      
+
       <div class="document">
     {%- block document %}
         <div class="documentwrapper">
@@ -205,26 +205,26 @@
       <div id="content" class="column">
         <section class="panel-display panel--generic  clearfix no-menu">
 
-  
-  
+
+
           <div class="panel-region--preface">
           <div class="inner region-inner inside">
           <div class="nist-breadcrumb"><a class="nist-breadcrumb__link"  href="https://www.nist.gov/services-resources/software">Software</a></div>
-            
+
           <div class="pane-social-share pane pane--social-share-social-share" >
-      
+
                   <h2 class="pane__title">Share</h2>
-            
-        
-        <div class="social-share clearfix"><a 
+
+
+        <div class="social-share clearfix"><a
         href="http://facebook.com/sharer.php?u=https%3A%2F%2Fwww.nist.gov%2Fctcms%2Ffipy&amp;t=FiPy" class="social-share-facebook" title="Facebook">Facebook</a>&nbsp;<a href="https://plus.google.com/share?url=https%3A%2F%2Fwww.nist.gov%2Fctcms%2Ffipy" class="social-share-googleplus" title="Google Plus">Google Plus</a>&nbsp;<a href="http://twitter.com/intent/tweet?url=https%3A%2F%2Fwww.nist.gov%2Fctcms%2Ffipy&amp;text=FiPy" class="social-share-twitter" title="Twitter">Twitter</a>&nbsp;</div>
-        
+
         </div>
           </div>
         </div>
-        
+
         <section class="content-area-container clearfix right-sidebar">
-        
+
 
   <div class="panel-region--content">
               <div class="body" role="main">
@@ -245,41 +245,41 @@
               {%- endif %}
                 </div>
               </div>
-  </div>  
+  </div>
   <div class="panel-region--right-sidebar">
   {%- block sidebar1 %}{{ sidebar() }}{% endblock %}
       <div class="clearer"></div>
   </div>
         </section>
 
-  
 
-  
+
+
       <div class="panel-region--postface">
       <div class="inner region-inner inside">
-        
+
 <div class="pane pane--nist-node-date-pane" >
-  
-            
-    
-    
+
+
+
+
     </div>
       </div>
     </div>
-  
+
 
         </section>
       </div>
 
       </div>
-  {%- endblock %}  
-    </div>          
+  {%- endblock %}
+    </div>
 
     </div>
 
   </div>
 
-    
+
 
 </div>
 {% endblock %}
@@ -307,7 +307,7 @@ Version {{ release }}
 
       <div class="footer__logo">
         <a href="https://www.nist.gov/" title="National Institute of Standards and Technology" class="footer__logo-link" rel="home">
-          <img srcset="https://www.nist.gov/sites/all/themes/nist_style/images/build/logo_rev.png" alt="National Institute of Standards and Technology logo" />
+          <img srcset="https://www.nist.gov/themes/custom/nist/dist/img/logo/nist_logo_sidestack_rev.svg" alt="National Institute of Standards and Technology logo" />
         </a>
       </div>
 
@@ -324,7 +324,7 @@ Version {{ release }}
 
       <div id="block-menu-block-1" class="block menu--footer-main-menu first odd block--menu-block block--menu-block-1" role="navigation">
 
-      
+
   <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-0 menu-level-1">
   <ul class="menu"><li  class="menu__item is-expanded first expanded menu-mlid-33106 menu-depth-1"><a href="https://www.nist.gov/topics" class="menu__link">Topics</a><ul class="menu"><li  class="menu__item is-leaf first leaf menu-mlid-32181 menu-depth-2"><a href="https://www.nist.gov/topics/advanced-communications" class="menu__link">Advanced Communications</a></li>
 <li  class="menu__item is-leaf leaf menu-mlid-135026 menu-depth-2"><a href="https://www.nist.gov/topics/artificial-intelligence" class="menu__link">Artificial Intelligence</a></li>
@@ -390,7 +390,7 @@ Version {{ release }}
 </div>
 <div id="block-menu-menu-footer-menu" class="block menu--footer-menu first even block--menu block--menu-menu-footer-menu" role="navigation">
 
-      
+
   <ul class="menu"><li  class="menu__item is-leaf first leaf menu-depth-1"><a href="https://www.nist.gov/privacy-policy" class="menu__link">Privacy Statement</a></li>
 <li  class="menu__item is-leaf leaf menu-depth-1"><a href="https://www.nist.gov/privacy-policy#privpolicy" class="menu__link">Privacy Policy</a></li>
 <li  class="menu__item is-leaf leaf menu-depth-1"><a href="https://www.nist.gov/privacy-policy#secnot" class="menu__link">Security Notice</a></li>
@@ -401,7 +401,7 @@ Version {{ release }}
 </div>
 <div id="block-menu-menu-footer-menu-2" class="block menu--footer-menu odd block--menu block--menu-menu-footer-menu-2" role="navigation">
 
-      
+
   <ul class="menu"><li  class="menu__item is-leaf first leaf menu-depth-1"><a href="https://www.nist.gov/disclaimer" class="menu__link">Disclaimer</a></li>
 <li  class="menu__item is-leaf leaf menu-depth-1"><a href="https://www.nist.gov/office-director/freedom-information-act" class="menu__link">FOIA</a></li>
 <li  class="menu__item is-leaf leaf menu-depth-1"><a href="https://www.nist.gov/privacy-policy#cookie" class="menu__link">Cookie Disclaimer</a></li>
@@ -411,7 +411,7 @@ Version {{ release }}
 </div>
 <div id="block-menu-menu-footer-menu-3" class="block menu--footer-menu last even block--menu block--menu-menu-footer-menu-3" role="navigation">
 
-      
+
   <ul class="menu"><li  class="menu__item is-leaf first leaf menu-depth-1"><a href="http://business.usa.gov/" class="menu__link">Business USA</a></li>
 <li  class="menu__item is-leaf leaf menu-depth-1"><a href="https://www.commerce.gov/" class="menu__link">Commerce.gov</a></li>
 <li  class="menu__item is-leaf leaf menu-depth-1"><a href="https://www.healthcare.gov/" class="menu__link">Healthcare.gov</a></li>


### PR DESCRIPTION
This is a temporary fix for the FiPy website so it uses the same logo links as the nist.gov pages. The NIST / MML theme may need to be abandoned (or use a more recent version) and [this](https://github.com/usnistgov/nist-header-footer) used instead. I wasn't sure how it all works so will leave that to @guyer unless he delegates.