### PR TITLE
Fix link to Nick Croft's thesis

### DIFF
--- a/documentation/refs.bib
+++ b/documentation/refs.bib
@@ -25,7 +25,7 @@
               Turbulent Reacting Flows},
    school =  {University of Greenwich},
    year =    1998,
-   url = {http://www.gre.ac.uk/~ct02/research/thesis/main.html}
+   url = {http://gala.gre.ac.uk/id/eprint/6371/}
 }
 
 @article{BoettingerReview:2002,
@@ -123,7 +123,7 @@
 
 @article{Wheeler:1992,
    author = {A. A. Wheeler and W. J. Boettinger and G. B. {McF}adden},
-   title = {Phase-field model for isothermal phase transitions in binary 
+   title = {Phase-field model for isothermal phase transitions in binary
             alloys},
    journal = {Physical Review A},
    volume =  45,
@@ -131,7 +131,7 @@
    year =    1992,
    pages =   {7424--7439},
 }
-   
+
 @article{CahnHilliardI,
 	author = {John W. Cahn and John E. Hilliard},
 	title = {Free energy of a nonuniform system. {I}. {I}nterfacial free energy},
@@ -248,7 +248,7 @@
 }
 
 @article{moffatInterface:2004,
-   author =  {T. P. Moffat and D. Wheeler and D. Josell}, 
+   author =  {T. P. Moffat and D. Wheeler and D. Josell},
    title =   {Superfilling and the Curvature Enhanced Accelerator Coverage Mechanism},
    journal = {The Electrochemical Society, Interface},
    volume =  13,
@@ -291,7 +291,7 @@
 }
 
 @Article{Hangarter:2011p2795,
-author = {C. M Hangarter and B. H Hamadani and J. E Guyer and H Xu and R Need and D Josell}, 
+author = {C. M Hangarter and B. H Hamadani and J. E Guyer and H Xu and R Need and D Josell},
 journal = {Journal of Applied Physics},
 title = {Three dimensionally structured interdigitated back contact thin film heterojunction solar cells},
 number = {7},
@@ -303,7 +303,7 @@ doi = {10.1063/1.3561487},
 }
 
 @Article{Saylor:2011p2794,
-author = {David M Saylor and Jonathan E Guyer and Daniel Wheeler and James A Warren}, 
+author = {David M Saylor and Jonathan E Guyer and Daniel Wheeler and James A Warren},
 journal = {Acta Biomaterialia},
 title = {Predicting microstructure development during casting of drug-eluting coatings},
 number = {2},
@@ -315,7 +315,7 @@ doi = {10.1016/j.actbio.2010.09.019},
 }
 
 @Article{Elder:2011p2811,
-author = {K. R Elder and K Thornton and J. J Hoyt}, 
+author = {K. R Elder and K Thornton and J. J Hoyt},
 journal = {Philosophical Magagazine},
 title = {The Kirkendall effect in the phase field crystal model},
 number = {1},


### PR DESCRIPTION
Nick Croft's thesis link is updated and fixed (couldn't find a
DOI). Excessive white space also removed from refs.bib.