### PR TITLE
fix: use open instead of file in py3

### DIFF
--- a/_setup/copy_script.py
+++ b/_setup/copy_script.py
@@ -54,7 +54,7 @@ class copy_script(Command):
         mod = imp.load_source("copy_script_module", self.From)
         script = fipy.tests.doctestPlus._getScript(name = "copy_script_module")
         script = "\n\n## This script was derived from\n## '%s'\n\n%s"%(self.From, script)
-        f = file(self.To, "w")
+        f = open(self.To, "w")
         f.write(script)
         f.close()
 

--- a/_setup/copy_script.py
+++ b/_setup/copy_script.py
@@ -54,8 +54,7 @@ class copy_script(Command):
         mod = imp.load_source("copy_script_module", self.From)
         script = fipy.tests.doctestPlus._getScript(name = "copy_script_module")
         script = "\n\n## This script was derived from\n## '%s'\n\n%s"%(self.From, script)
-        f = open(self.To, "w")
-        f.write(script)
-        f.close()
+        with open(self.To, "w") as f:
+            f.write(script)
 
         print("Script code exported from '%s' to '%s'"%(self.From, self.To))


### PR DESCRIPTION
Address #692

Use the open function instead of the file function in Python 3. The
copy_script command still had the Python 2 syntax.