### PR TITLE
build(nix): fix broken plm_rsh_agent error

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -29,6 +29,8 @@ in
       export PYTHONPATH=$PYTHONPATH:$USER_SITE
       export PATH=$PATH:$PYTHONUSERBASE/bin
 
+      export OMPI_MCA_plm_rsh_agent=/usr/bin/ssh
+
       ## To build the docs
       # pip install --user sphinx
       # pip install --user "sphinxcontrib-bibtex<=0.4.2"


### PR DESCRIPTION
Fix issue with path to SSH for MPI when firing up the Nix shell.