### PR TITLE
Issue662 issues scaling colorbar with datamin and datamax args

### DIFF
--- a/fipy/viewers/matplotlibViewer/matplotlib2DGridContourViewer.py
+++ b/fipy/viewers/matplotlibViewer/matplotlib2DGridContourViewer.py
@@ -69,6 +69,8 @@ class Matplotlib2DGridContourViewer(AbstractMatplotlib2DViewer):
         return [vars[0]]
 
     def _plot(self):
+        super(Matplotlib2DGridContourViewer, self)._plot()
+
 ##         plt.clf()
 
 ##         ## Added garbage collection since matplotlib objects seem to hang
@@ -82,15 +84,10 @@ class Matplotlib2DGridContourViewer(AbstractMatplotlib2DViewer):
         Z = self.vars[0].value
         X, Y, Z = [v.reshape(shape, order='F') for v in (X, Y, Z)]
 
-        zmin, zmax = self._autoscale(vars=self.vars,
-                                     datamin=self._getLimit(('datamin', 'zmin')),
-                                     datamax=self._getLimit(('datamax', 'zmax')))
-
-        self.norm.vmin = zmin
-        self.norm.vmax = zmax
-
         numberOfContours = 10
         smallNumber = 1e-7
+        zmin = self.norm.vmin
+        zmax = self.norm.vmax
         diff = zmax - zmin
 
         if diff < smallNumber:
@@ -105,10 +102,6 @@ class Matplotlib2DGridContourViewer(AbstractMatplotlib2DViewer):
 
         self.axes.set_ylim(ymin=self._getLimit('ymin'),
                            ymax=self._getLimit('ymax'))
-
-        if self.colorbar is not None:
-            self.colorbar.plot()
-
 
 def _test():
     from fipy.viewers.viewer import _test2D

--- a/fipy/viewers/matplotlibViewer/matplotlib2DGridContourViewer.py
+++ b/fipy/viewers/matplotlibViewer/matplotlib2DGridContourViewer.py
@@ -55,11 +55,11 @@ class Matplotlib2DGridContourViewer(AbstractMatplotlib2DViewer):
         self._plot()
 
     def _getSuitableVars(self, vars):
-        from fipy.meshes.grid2D import Grid2D
+        from fipy.meshes.nonUniformGrid2D import NonUniformGrid2D
         from fipy.meshes.uniformGrid2D import UniformGrid2D
         from fipy.variables.cellVariable import CellVariable
         vars = [var for var in AbstractMatplotlib2DViewer._getSuitableVars(self, vars) \
-          if ((isinstance(var.mesh, Grid2D)
+          if ((isinstance(var.mesh, NonUniformGrid2D)
                or isinstance(var.mesh, UniformGrid2D))
               and isinstance(var, CellVariable))]
         if len(vars) == 0:

--- a/fipy/viewers/matplotlibViewer/matplotlib2DGridViewer.py
+++ b/fipy/viewers/matplotlibViewer/matplotlib2DGridViewer.py
@@ -47,14 +47,6 @@ class Matplotlib2DGridViewer(AbstractMatplotlib2DViewer):
                                             cmap=cmap, colorbar=colorbar, axes=axes, figaspect=figaspect,
                                             **kwlimits)
 
-        xmin, ymin = self.vars[0].mesh.extents['min']
-        xmax, ymax = self.vars[0].mesh.extents['max']
-
-        self.image = self.axes.imshow(self._data,
-                                      extent=(xmin, xmax, ymin, ymax),
-                                      vmin=0, vmax=1,
-                                      cmap=self.cmap)
-
         self.axes.set_xlim(xmin=self._getLimit('xmin'),
                            xmax=self._getLimit('xmax'))
 
@@ -90,19 +82,24 @@ class Matplotlib2DGridViewer(AbstractMatplotlib2DViewer):
         # this viewer can only display one variable
         return [vars[0]]
 
+    def _make_mappable(self):
+        xmin, ymin = self.vars[0].mesh.extents['min']
+        xmax, ymax = self.vars[0].mesh.extents['max']
+
+        self.image = self.axes.imshow(self._data,
+                                      extent=(xmin, xmax, ymin, ymax),
+                                      norm=self.norm,
+                                      cmap=self.cmap)
+        return self.image
+
     @property
     def _data(self):
         from fipy.tools.numerix import array, reshape
         return reshape(array(self.vars[0]), self.vars[0].mesh.shape[::-1])[::-1]
 
     def _plot(self):
-        self.norm.vmin = self._getLimit(('datamin', 'zmin'))
-        self.norm.vmax = self._getLimit(('datamax', 'zmax'))
-
-        self.image.set_data(self.norm(self._data))
-
-        if self.colorbar is not None:
-            self.colorbar.plot()
+        super(Matplotlib2DGridViewer, self)._plot()
+        self.image.set_data(self._data)
 
 def _test():
     from fipy.viewers.viewer import _test2D

--- a/fipy/viewers/matplotlibViewer/matplotlib2DViewer.py
+++ b/fipy/viewers/matplotlibViewer/matplotlib2DViewer.py
@@ -4,7 +4,7 @@ __docformat__ = 'restructuredtext'
 
 from fipy.tools import numerix
 
-from fipy.viewers.matplotlibViewer.matplotlibViewer import AbstractMatplotlibViewer, _ColorBar
+from fipy.viewers.matplotlibViewer.matplotlibViewer import AbstractMatplotlibViewer
 
 __all__ = ["Matplotlib2DViewer"]
 from future.utils import text_to_native_str
@@ -15,6 +15,16 @@ class AbstractMatplotlib2DViewer(AbstractMatplotlibViewer):
         if figaspect == 'auto':
             figaspect = self.vars[0].mesh.aspect2D
         return figaspect
+
+    def _plot(self):
+        zmin, zmax = self._autoscale(vars=self.vars,
+                                     datamin=self._getLimit(('datamin', 'zmin')),
+                                     datamax=self._getLimit(('datamax', 'zmax')))
+
+        self.norm.vmin = zmin
+        self.norm.vmax = zmax
+
+        self.mappable.set_norm(self.norm)
 
 class Matplotlib2DViewer(AbstractMatplotlib2DViewer):
     """
@@ -108,6 +118,8 @@ class Matplotlib2DViewer(AbstractMatplotlib2DViewer):
         return [vars[0]]
 
     def _plot(self):
+        super(Matplotlib2DViewer, self)._plot()
+
 ##         plt.clf()
 
 ##         ## Added garbage collection since matplotlib objects seem to hang
@@ -117,16 +129,10 @@ class Matplotlib2DViewer(AbstractMatplotlib2DViewer):
 
         Z = self.vars[0].value
 
-        self.norm.vmin = self._getLimit(('datamin', 'zmin'))
-        self.norm.vmax = self._getLimit(('datamax', 'zmax'))
-
         rgba = self.cmap(self.norm(Z))
 
         self.collection.set_facecolors(rgba)
         self.collection.set_edgecolors(rgba)
-
-        if self.colorbar is not None:
-            self.colorbar.plot() #vmin=zmin, vmax=zmax)
 
 ##        plt.xlim(xmin=self._getLimit('xmin'),
 ##                 xmax=self._getLimit('xmax'))

--- a/fipy/viewers/matplotlibViewer/matplotlib2DViewer.py
+++ b/fipy/viewers/matplotlibViewer/matplotlib2DViewer.py
@@ -11,9 +11,18 @@ from future.utils import text_to_native_str
 __all__ = [text_to_native_str(n) for n in __all__]
 
 class AbstractMatplotlib2DViewer(AbstractMatplotlibViewer):
-    def figaspect(self, figaspect):
+    def figaspect(self, figaspect, colorbar):
         if figaspect == 'auto':
             figaspect = self.vars[0].mesh.aspect2D
+            # We can't make the colorbar, yet (as we don't even have a figure)
+            # so hardcode these values, based on
+            # https://matplotlib.org/api/_as_gen/matplotlib.figure.Figure.html#matplotlib.figure.Figure.colorbar
+            #   fraction	0.15; fraction of original axes to use for colorbar
+            #   pad	        0.05 if vertical, 0.15 if horizontal; fraction of original axes between colorbar and new image axes
+            if colorbar == "vertical":
+                figaspect = figaspect * (1. - (0.15 + 0.05))
+            elif colorbar == "horizontal":
+                figaspect = figaspect / (1. - (0.15 + 0.15))
         return figaspect
 
     def _plot(self):

--- a/fipy/viewers/matplotlibViewer/matplotlibViewer.py
+++ b/fipy/viewers/matplotlibViewer/matplotlibViewer.py
@@ -132,7 +132,11 @@ class AbstractMatplotlibViewer(AbstractViewer):
 
     def _make_mappable(self):
         import matplotlib
-        return matplotlib.cm.ScalarMappable(norm=self.norm, cmap=self.cmap)
+        mappable = matplotlib.cm.ScalarMappable(norm=self.norm, cmap=self.cmap)
+        # ignored, but needed for matplotlib < 3.0 (Py2k)
+        mappable.set_array(self.vars[0].value)
+
+        return mappable
 
     @property
     def mappable(self):

--- a/fipy/viewers/matplotlibViewer/matplotlibViewer.py
+++ b/fipy/viewers/matplotlibViewer/matplotlibViewer.py
@@ -152,11 +152,15 @@ class AbstractMatplotlibViewer(AbstractViewer):
             return isinstance(self.norm, colors.LogNorm)
 
         def fset(self, value):
+            zmin, zmax = self._autoscale(vars=self.vars,
+                                         datamin=self._getLimit(('datamin', 'zmin')),
+                                         datamax=self._getLimit(('datamax', 'zmax')))
+
             from matplotlib import colors
             if value:
-                self.norm = colors.LogNorm()
+                self.norm = colors.LogNorm(vmin=zmin, vmax=zmax)
             else:
-                self.norm = colors.Normalize()
+                self.norm = colors.Normalize(vmin=zmin, vmax=zmax)
 
             self.mappable.set_norm(self.norm)
 

--- a/fipy/viewers/matplotlibViewer/matplotlibViewer.py
+++ b/fipy/viewers/matplotlibViewer/matplotlibViewer.py
@@ -96,7 +96,7 @@ class AbstractMatplotlibViewer(AbstractViewer):
         plt.ion()
 
         if axes is None:
-            w, h = plt.figaspect(self.figaspect(figaspect))
+            w, h = plt.figaspect(self.figaspect(figaspect, colorbar))
             self.fig = plt.figure(figsize=(w, h))
             self.axes = plt.gca()
         else:
@@ -127,7 +127,7 @@ class AbstractMatplotlibViewer(AbstractViewer):
         else:
             self.colorbar = None
 
-    def figaspect(self, figaspect):
+    def figaspect(self, figaspect, colorbar):
         return figaspect
 
     def _make_mappable(self):

--- a/fipy/viewers/matplotlibViewer/test.py
+++ b/fipy/viewers/matplotlibViewer/test.py
@@ -14,6 +14,7 @@ def _suite():
         'matplotlib2DViewer',
         'matplotlib2DGridViewer',
         'matplotlib2DGridContourViewer',
+        'matplotlibStreamViewer',
         'matplotlibVectorViewer',
         ), base = __name__)
 


### PR DESCRIPTION
Fix a number of issues with colorbars that came with Matplotlib 3.

Turns out we were never using norms correctly. Hopefully better now.

Fixes #662. Fixes #663.