### PR TITLE
Spherical1D (Uniform and NonUniform) meshes

### DIFF
--- a/fipy/meshes/factoryMeshes.py
+++ b/fipy/meshes/factoryMeshes.py
@@ -5,7 +5,7 @@ __docformat__ = 'restructuredtext'
 from fipy.tools import parallelComm
 from fipy.tools import numerix
 
-__all__ = ["Grid3D", "Grid2D", "Grid1D", "CylindricalGrid2D", "CylindricalGrid1D"]
+__all__ = ["Grid3D", "Grid2D", "Grid1D", "CylindricalGrid2D", "CylindricalGrid1D", "SphericalGrid1D"]
 from future.utils import text_to_native_str
 __all__ = [text_to_native_str(n) for n in __all__]
 
@@ -286,6 +286,47 @@ def CylindricalGrid1D(dr=None, nr=None, Lr=None,
         from fipy.meshes.cylindricalNonUniformGrid1D import CylindricalNonUniformGrid1D
         return CylindricalNonUniformGrid1D(dx=dx, nx=nx, origin=origin, overlap=overlap, communicator=parallelComm)
 
+def SphericalGrid1D(dr=None, nr=None, Lr=None,
+                    dx=1., nx=None, Lx=None,
+                    origin=(0,), overlap=2, communicator=parallelComm):
+
+    r""" Factory function to select between `SphericalUniformGrid1D` and
+    `SphericalNonUniformGrid1D`. If `Lr` is specified the length of the
+    domain is always `Lr` regardless of `dr`, unless `dr` is a list of
+    spacings, in which case `Lr` will be the sum of `dr`.
+
+    Parameters
+    ----------
+    dr : float
+        Grid spacing in the radial direction. Alternative: `dx`.
+    nr : int
+        Number of cells in the radial direction. Alternative: `nx`.
+    Lr : float
+        Domain length in the radial direction. Alternative: `Lx`.
+    overlap : int
+        the number of overlapping cells for parallel
+        simulations. Generally 2 is adequate. Higher order equations or
+        discretizations require more.
+    communicator : ~fipy.tools.comms.commWrapper.CommWrapper
+        Generally, `fipy.tools.serialComm` or `fipy.tools.parallelComm`.
+        Select `~fipy.tools.serialComm` to create a serial mesh when
+        running in parallel; mostly used for test purposes.
+    """
+
+    if dr is not None:
+        dx = dr
+
+    nx = nr or nx
+    Lx = Lr or Lx
+
+    if numerix.getShape(dx) == ():
+        dx, nx = _dnl(dx, nx, Lx)
+        from fipy.meshes.sphericalUniformGrid1D import SphericalUniformGrid1D
+        return SphericalUniformGrid1D(dx=dx, nx=nx or 1, origin=origin, overlap=overlap, communicator=parallelComm)
+    else:
+        from fipy.meshes.sphericalNonUniformGrid1D import SphericalNonUniformGrid1D
+        return SphericalNonUniformGrid1D(dx=dx, nx=nx, origin=origin, overlap=overlap, communicator=parallelComm)
+    
 def _test():
     import fipy.tests.doctestPlus
     return fipy.tests.doctestPlus.testmod()

--- a/fipy/meshes/sphericalNonUniformGrid1D.py
+++ b/fipy/meshes/sphericalNonUniformGrid1D.py
@@ -1,0 +1,112 @@
+"""
+1D Mesh
+"""
+from __future__ import unicode_literals
+__docformat__ = 'restructuredtext'
+
+from fipy.tools import numerix
+from fipy.tools.dimensions.physicalField import PhysicalField
+from fipy.tools import parallelComm
+
+from fipy.meshes.nonUniformGrid1D import NonUniformGrid1D
+
+__all__ = ["SphericalNonUniformGrid1D"]
+from future.utils import text_to_native_str
+__all__ = [text_to_native_str(n) for n in __all__]
+
+class SphericalNonUniformGrid1D(NonUniformGrid1D):
+    """
+    Creates a 1D spherical grid mesh.
+
+        >>> mesh = SphericalNonUniformGrid1D(nx = 3)
+        >>> print(mesh.cellCenters)
+        [[ 0.5  1.5  2.5]]
+
+        >>> mesh = SphericalNonUniformGrid1D(dx = (1, 2, 3))
+        >>> print(mesh.cellCenters)
+        [[ 0.5  2.   4.5]]
+
+        >>> print(numerix.allclose(mesh.cellVolumes, (0.5, 4., 13.5))) # doctest: +PROCESSOR_0
+        True
+
+        >>> mesh = SphericalNonUniformGrid1D(nx = 2, dx = (1, 2, 3))
+        Traceback (most recent call last):
+        ...
+        IndexError: nx != len(dx)
+
+        >>> mesh = SphericalNonUniformGrid1D(nx=2, dx=(1., 2.)) + ((1.,),)
+        >>> print(mesh.cellCenters)
+        [[ 1.5  3. ]]
+        >>> print(numerix.allclose(mesh.cellVolumes, (1.5, 6))) # doctest: +PROCESSOR_0
+        True
+
+    """
+    def __init__(self, dx=1., nx=None, origin=(0,), overlap=2, communicator=parallelComm, *args, **kwargs):
+        scale = PhysicalField(value=1, unit=PhysicalField(value=dx).unit)
+        self.origin = PhysicalField(value=origin)
+        self.origin /= scale
+
+        super(SphericalNonUniformGrid1D, self).__init__(dx=dx,
+                                                        nx=nx,
+                                                        overlap=overlap,
+                                                        communicator=communicator,
+                                                        *args,
+                                                        **kwargs)
+
+        self.vertexCoords += origin
+        self.args['origin'] = origin
+
+    def _calcFaceCenters(self):
+        faceCenters = super(SphericalNonUniformGrid1D, self)._calcFaceCenters()
+        return faceCenters + self.origin
+
+    def _calcFaceAreas(self):
+        return self._calcFaceCenters()[0] * self._calcFaceCenters()[0]
+
+    def _calcCellVolumes(self):
+        return super(SphericalNonUniformGrid1D, self)._calcCellVolumes() / 2.
+
+    def _translate(self, vector):
+        return SphericalNonUniformGrid1D(dx=self.args['dx'], nx=self.args['nx'],
+                                         origin=numerix.array(self.args['origin']) + vector,
+                                         overlap=self.args['overlap'])
+
+    def __mul__(self, factor):
+        return SphericalNonUniformGrid1D(dx=self.args['dx'] * factor, nx=self.args['nx'],
+                                         origin=numerix.array(self.args['origin']) * factor,
+                                         overlap=self.args['overlap'])
+
+    def _test(self):
+        """
+        These tests are not useful as documentation, but are here to ensure
+        everything works as expected. Fixed a bug where the following throws
+        an error on solve() when `nx` is a float.
+
+            >>> from fipy import CellVariable, DiffusionTerm
+            >>> mesh = SphericalNonUniformGrid1D(nx=3., dx=(1., 2., 3.))
+            >>> var = CellVariable(mesh=mesh)
+            >>> DiffusionTerm().solve(var)
+
+        This test is for https://github.com/usnistgov/fipy/issues/372. Cell
+        volumes were being returned as `binOps` rather than arrays.
+
+            >>> m = SphericalNonUniformGrid1D(dx=(1., 2., 3., 4.), nx=4)
+            >>> print(isinstance(m.cellVolumes, numerix.ndarray))
+            True
+            >>> print(isinstance(m._faceAreas, numerix.ndarray))
+            True
+
+        If the above types aren't correct, the divergence operator's value can be a `binOp`
+
+            >>> print(isinstance(CellVariable(mesh=m).arithmeticFaceValue.divergence.value, numerix.ndarray))
+            True
+
+        """
+
+def _test():
+    import fipy.tests.doctestPlus
+    return fipy.tests.doctestPlus.testmod()
+
+if __name__ == "__main__":
+    _test()
+

--- a/fipy/meshes/sphericalNonUniformGrid1D.py
+++ b/fipy/meshes/sphericalNonUniformGrid1D.py
@@ -83,8 +83,9 @@ class SphericalNonUniformGrid1D(NonUniformGrid1D):
         an error on solve() when `nx` is a float.
 
             >>> from fipy import CellVariable, DiffusionTerm
-            >>> mesh = SphericalNonUniformGrid1D(nx=3., dx=(1., 2., 3.)) + ((0.01,))
+            >>> mesh = SphericalNonUniformGrid1D(nx=3., dx=(1., 2., 3.))
             >>> var = CellVariable(mesh=mesh)
+            >>> var.constrain(0., where=mesh.facesRight)
             >>> DiffusionTerm().solve(var)
 
         This test is for https://github.com/usnistgov/fipy/issues/372. Cell

--- a/fipy/meshes/sphericalNonUniformGrid1D.py
+++ b/fipy/meshes/sphericalNonUniformGrid1D.py
@@ -83,7 +83,7 @@ class SphericalNonUniformGrid1D(NonUniformGrid1D):
         an error on solve() when `nx` is a float.
 
             >>> from fipy import CellVariable, DiffusionTerm
-            >>> mesh = SphericalNonUniformGrid1D(nx=3., dx=(1., 2., 3.))
+            >>> mesh = SphericalNonUniformGrid1D(nx=3., dx=(1., 2., 3.)) + ((0.01,))
             >>> var = CellVariable(mesh=mesh)
             >>> DiffusionTerm().solve(var)
 

--- a/fipy/meshes/sphericalNonUniformGrid1D.py
+++ b/fipy/meshes/sphericalNonUniformGrid1D.py
@@ -26,7 +26,7 @@ class SphericalNonUniformGrid1D(NonUniformGrid1D):
         >>> print(mesh.cellCenters)
         [[ 0.5  2.   4.5]]
 
-        >>> print(numerix.allclose(mesh.cellVolumes, (0.5, 4., 13.5))) # doctest: +PROCESSOR_0
+        >>> print(numerix.allclose(mesh.cellVolumes, (0.5, 13., 94.5))) # doctest: +PROCESSOR_0
         True
 
         >>> mesh = SphericalNonUniformGrid1D(nx = 2, dx = (1, 2, 3))
@@ -37,7 +37,7 @@ class SphericalNonUniformGrid1D(NonUniformGrid1D):
         >>> mesh = SphericalNonUniformGrid1D(nx=2, dx=(1., 2.)) + ((1.,),)
         >>> print(mesh.cellCenters)
         [[ 1.5  3. ]]
-        >>> print(numerix.allclose(mesh.cellVolumes, (1.5, 6))) # doctest: +PROCESSOR_0
+        >>> print(numerix.allclose(mesh.cellVolumes, (3.5, 28))) # doctest: +PROCESSOR_0
         True
 
     """

--- a/fipy/meshes/sphericalUniformGrid1D.py
+++ b/fipy/meshes/sphericalUniformGrid1D.py
@@ -62,7 +62,7 @@ class SphericalUniformGrid1D(UniformGrid1D):
         everything works as expected. The following was broken, now fixed.
 
             >>> from fipy import *
-            >>> mesh = SphericalUniformGrid1D(nx=3., dx=1.)
+            >>> mesh = SphericalUniformGrid1D(nx=3., dx=1.) + ((0.01,))
             >>> var = CellVariable(mesh=mesh)
             >>> DiffusionTerm().solve(var)
 

--- a/fipy/meshes/sphericalUniformGrid1D.py
+++ b/fipy/meshes/sphericalUniformGrid1D.py
@@ -31,7 +31,7 @@ class SphericalUniformGrid1D(UniformGrid1D):
                                       nx=self.args['nx'],
                                       origin=self.args['origin'] + numerix.array(vector),
                                       overlap=self.args['overlap'])
-    
+
     @property
     def _faceAreas(self):
         return self.faceCenters[0].value * self.faceCenters[0].value

--- a/fipy/meshes/sphericalUniformGrid1D.py
+++ b/fipy/meshes/sphericalUniformGrid1D.py
@@ -62,8 +62,9 @@ class SphericalUniformGrid1D(UniformGrid1D):
         everything works as expected. The following was broken, now fixed.
 
             >>> from fipy import *
-            >>> mesh = SphericalUniformGrid1D(nx=3., dx=1.) + ((0.01,))
+            >>> mesh = SphericalUniformGrid1D(nx=3., dx=1.)
             >>> var = CellVariable(mesh=mesh)
+            >>> var.constrain(0., where=mesh.facesRight)
             >>> DiffusionTerm().solve(var)
 
         This test is for https://github.com/usnistgov/fipy/issues/372. Cell

--- a/fipy/meshes/sphericalUniformGrid1D.py
+++ b/fipy/meshes/sphericalUniformGrid1D.py
@@ -1,0 +1,91 @@
+"""
+1D Mesh
+"""
+from __future__ import division
+from __future__ import unicode_literals
+__docformat__ = 'restructuredtext'
+
+from fipy.meshes.uniformGrid1D import UniformGrid1D
+from fipy.tools import numerix
+from fipy.tools.numerix import MA
+from fipy.tools import parallelComm
+
+__all__ = ["SphericalUniformGrid1D"]
+from future.utils import text_to_native_str
+__all__ = [text_to_native_str(n) for n in __all__]
+
+class SphericalUniformGrid1D(UniformGrid1D):
+    """
+    Creates a 1D spherical grid mesh.
+
+        >>> mesh = SphericalUniformGrid1D(nx = 3)
+        >>> print(mesh.cellCenters)
+        [[ 0.5  1.5  2.5]]
+
+    """
+    def __init__(self, dx=1., nx=1, origin=(0,), overlap=2, communicator=parallelComm, *args, **kwargs):
+        UniformGrid1D.__init__(self, dx=dx, nx=nx, origin=origin, overlap=overlap, communicator=communicator, *args, **kwargs)
+
+    def _translate(self, vector):
+        return SphericalUniformGrid1D(dx=self.args['dx'],
+                                      nx=self.args['nx'],
+                                      origin=self.args['origin'] + numerix.array(vector),
+                                      overlap=self.args['overlap'])
+    
+    @property
+    def _faceAreas(self):
+        return self.faceCenters[0].value * self.faceCenters[0].value
+
+    @property
+    def _cellAreas(self):
+        return numerix.array((self.faceAreas[:-1], self.faceAreas[1:]))
+
+    @property
+    def _cellAreaProjections(self):
+        return MA.array(self.cellNormals) * self.cellAreas
+
+    @property
+    def _faceAspectRatios(self):
+        return self._faceAreas / self._cellDistances
+
+    @property
+    def _areaProjections(self):
+        return self.faceNormals * self._faceAreas
+
+    @property
+    def cellVolumes(self):
+        return self.dx * self.cellCenters[0].value * self.cellCenters[0].value
+
+    def _test(self):
+        """
+        These tests are not useful as documentation, but are here to ensure
+        everything works as expected. The following was broken, now fixed.
+
+            >>> from fipy import *
+            >>> mesh = SphericalUniformGrid1D(nx=3., dx=1.)
+            >>> var = CellVariable(mesh=mesh)
+            >>> DiffusionTerm().solve(var)
+
+        This test is for https://github.com/usnistgov/fipy/issues/372. Cell
+        volumes were being returned as `binOps` rather than arrays.
+
+            >>> m = SphericalUniformGrid1D(dx=1., nx=4)
+            >>> print(isinstance(m.cellVolumes, numerix.ndarray))
+            True
+            >>> print(isinstance(m._faceAreas, numerix.ndarray))
+            True
+
+        If the above types aren't correct, the divergence operator's value can be a `binOp`
+
+            >>> print(isinstance(CellVariable(mesh=m).arithmeticFaceValue.divergence.value, numerix.ndarray))
+            True
+
+        """
+
+def _test():
+    import fipy.tests.doctestPlus
+    return fipy.tests.doctestPlus.testmod()
+
+if __name__ == "__main__":
+    _test()
+

--- a/fipy/meshes/test.py
+++ b/fipy/meshes/test.py
@@ -26,6 +26,8 @@ def _suite():
         'fipy.meshes.cylindricalUniformGrid2D',
         'fipy.meshes.cylindricalNonUniformGrid1D',
         'fipy.meshes.cylindricalNonUniformGrid2D',
+        'fipy.meshes.sphericalUniformGrid1D',
+        'fipy.meshes.sphericalNonUniformGrid1D',
         'fipy.meshes.factoryMeshes',
         'fipy.meshes.abstractMesh',
         'fipy.meshes.representations.gridRepresentation'))


### PR DESCRIPTION
Based on the suggestion in this stack overflow question:

https://stackoverflow.com/questions/52242891/1d-spherical-grid-in-fipy

I have created two simple 1D spherical meshes (uniform and non-uniform), by adding an extra "r" term in the area calculations of the 1D cylindrical mesh.

Aside from trivial naming differences, the diff between the uniform cylindrical and spherical versions mainly is:

```
37c37
<         return self.faceCenters[0].value
---
>         return self.faceCenters[0].value * self.faceCenters[0].value
57c57
<         return self.dx * self.cellCenters[0].value
---
>         return self.dx * self.cellCenters[0].value * self.cellCenters[0].value

```