### PR TITLE
Debug CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
 
     steps:
       - install_conda_packages:
-          packages: "python=2.7 fipy traitsui<=7.0.0"
+          packages: "python=2.7 fipy \"traitsui<=7.0.0\""
           condaenv: "test-environment-27"
 
   conda3_env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
 
     steps:
       - install_conda_packages:
-          packages: "python=2.7 fipy \"traitsui<=7.0.0\""
+          packages: "python=2.7 fipy \"traitsui<7.0.0\""
           condaenv: "test-environment-27"
 
   conda3_env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,11 @@ commands:
           at: ~/project
 
       - run:
+          name: Output Environment
+          command: |
+            conda env export --prefix ~/project/<< parameters.condaenv >>
+
+      - run:
           name: Run Tests
           no_output_timeout: 30m
           command: |
@@ -79,11 +84,6 @@ commands:
               << parameters.mpirun >> python setup.py test > /dev/null 2>&1 || true;
             fi
             << parameters.mpirun >> python setup.py test --deprecation-errors
-
-      - run:
-          name: Output Environment
-          command: |
-            conda env export --prefix ~/project/<< parameters.condaenv >>
 
       - store_artifacts:
           path: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
 
     steps:
       - install_conda_packages:
-          packages: "python=2.7 fipy"
+          packages: "python=2.7 fipy traitsui<=7.0.0"
           condaenv: "test-environment-27"
 
   conda3_env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -612,16 +612,16 @@ workflows:
       - build-binaries:
           requires:
             - conda3_env
-            - build-36-docs
-            - pylint
-            - flake8
-            - black
-            - pyspelling
-            - test-27-pysparse
-            - test-27-trilinos-serial
-            - test-27-trilinos-parallel
-            - test-27-petsc-serial
-            - test-27-petsc-parallel
-            - test-36-scipy
-            - test-36-petsc-serial
-            - test-36-petsc-parallel
+#             - build-36-docs
+#             - pylint
+#             - flake8
+#             - black
+#             - pyspelling
+#             - test-27-pysparse
+#             - test-27-trilinos-serial
+#             - test-27-trilinos-parallel
+#             - test-27-petsc-serial
+#             - test-27-petsc-parallel
+#             - test-36-scipy
+#             - test-36-petsc-serial
+#             - test-36-petsc-parallel

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
   - source activate test-environment
   - conda remove --quiet --channel conda-forge --force fipy
   - if [[ $PY3k -eq 0 ]]; then
-      conda install --channel conda-forge "traitsui<=7.0.0";
+      conda install --channel conda-forge "traitsui<7.0.0";
     fi
   # Useful for debugging any issues with conda
   - conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,9 @@ before_install:
   - conda create --quiet --name test-environment --show-channel-urls --channel conda-forge python=$TRAVIS_PYTHON_VERSION fipy "gmsh<4.0";
   - source activate test-environment
   - conda remove --quiet --channel conda-forge --force fipy
+  - if [[ $PY3k -eq 0 ]]; then
+      conda install --channel conda-forge traitsui<=7.0.0
+    fi
   # Useful for debugging any issues with conda
   - conda info -a
   - pip install scikit-fmm

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
   - source activate test-environment
   - conda remove --quiet --channel conda-forge --force fipy
   - if [[ $PY3k -eq 0 ]]; then
-      conda install --channel conda-forge traitsui<=7.0.0
+      conda install --channel conda-forge "traitsui<=7.0.0"
     fi
   # Useful for debugging any issues with conda
   - conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - conda create --quiet --name test-environment --show-channel-urls --channel conda-forge python=$TRAVIS_PYTHON_VERSION fipy "gmsh<4.0";
   - source activate test-environment
   - conda remove --quiet --channel conda-forge --force fipy
-  - if [[ $PY3k -eq 0 ]]; then
+  - if [[ $PY3K -eq 0 ]]; then
       conda install --channel conda-forge "traitsui<7.0.0";
     fi
   # Useful for debugging any issues with conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
   - source activate test-environment
   - conda remove --quiet --channel conda-forge --force fipy
   - if [[ $PY3k -eq 0 ]]; then
-      conda install --channel conda-forge "traitsui<=7.0.0"
+      conda install --channel conda-forge "traitsui<=7.0.0";
     fi
   # Useful for debugging any issues with conda
   - conda info -a

--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -92,7 +92,20 @@ Recommended Method
       activate <MYFIPYENV>
       pip install fipy
 
+  .. attention::
+
+     Bit rot has started to set in for Python 2.7.  One consequence is that
+     :class:`~fipy.viewers.vtkViewer.VTKViewer`\s can raise errors
+     (probably other uses of :term:`Mayavi`, too).  You can remedy this by
+     creating your environment with::
+
+     $ conda create --name <MYFIPYENV> --channel conda-forge python=2.7 fipy "traitsui<7.0.0"
+
 * enable this new environment with::
+
+    $ conda activate <MYFIPYENV>
+
+  or
 
     $ source activate <MYFIPYENV>
 

--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,7 @@ or a
 .. |CircleCI|      image:: https://img.shields.io/circleci/project/github/usnistgov/fipy/master.svg?label=Linux
 .. _CircleCI:      https://circleci.com/gh/usnistgov/fipy
 .. |TravisCI|      image:: https://img.shields.io/travis/usnistgov/fipy/master.svg?label=macOS
-.. _TravisCI:      https://travis-ci.org/usnistgov/fipy
+.. _TravisCI:      https://travis-ci.com/github/usnistgov/fipy
 .. |AppVeyor|      image:: https://ci.appveyor.com/api/projects/status/github/usnistgov/fipy?branch=master&svg=true&failingText=Windows%20-%20failing&passingText=Windows%20-%20passing&pendingText=Windows%20-%20pending
 .. _AppVeyor:      https://ci.appveyor.com/project/usnistgov/fipy
 .. |OpenHub|       image:: https://www.openhub.net/p/fipy/widgets/project_thin_badge.gif

--- a/examples/elphf/diffusion/mesh1D.py
+++ b/examples/elphf/diffusion/mesh1D.py
@@ -115,9 +115,15 @@ Now, we iterate the problem to equilibrium, plotting as we go
 Since there is nothing to maintain the concentration separation in this problem,
 we verify that the concentrations have become uniform
 
->>> print(substitutionals[0].allclose(0.45, rtol = 1e-7, atol = 1e-7))
+.. note::
+
+   Between `petsc=3.13.2=h82b89f7_0` and `petsc=3.13.4=h82b89f7_0`, PETSc
+   ceased achieving 1e-7 tolerance when solving on 2 processors on Linux.
+   Solving on macOS is OK. Solving on 1, 3, or 4 processors is OK.
+
+>>> print(substitutionals[0].allclose(0.45, rtol = 2e-7, atol = 2e-7))
 True
->>> print(substitutionals[1].allclose(0.45, rtol = 1e-7, atol = 1e-7))
+>>> print(substitutionals[1].allclose(0.45, rtol = 2e-7, atol = 2e-7))
 True
 """
 from __future__ import unicode_literals


### PR DESCRIPTION
Multiple failures on the CIs render them unhelpful:

- [x] `VTKViewer` "`cannot import name getfullargspec`" on Py2k (#750)
- [x] `examples/elphf/diffusion/mesh1D.py` fails on Py3k with PETSc and 2 processors

Other CI issues that made debugging harder:

- [x] CircleCI doesn't output conda environment unless tests passed
- [x] CircleCI doesn't build and store artifacts unless *all* other steps pass
- [x] https://travis-ci.org migrated to https://travis-ci.com