### PR TITLE
Tabulate versions of FiPy dependencies when tests are run

### DIFF
--- a/fipy/tests/test.py
+++ b/fipy/tests/test.py
@@ -6,6 +6,7 @@ from future.utils import text_to_native_str
 from future.utils import string_types
 import unittest
 import warnings
+import sys
 
 __all__ = [text_to_native_str("test")]
 
@@ -146,57 +147,70 @@ class test(_test):
             yield "examples.test._suite"
 
     def printPackageInfo(self):
+        packages = ['python']
+        versions = [sys.version.replace('\n', '| ')]
 
         for pkg in ['fipy', 'numpy', 'pysparse', 'scipy', 'matplotlib', 'mpi4py', 'petsc4py', 'pyamgx']:
+            packages.append(pkg)
 
             try:
                 mod = __import__(pkg)
 
-                if hasattr(mod, '__version__'):
-                    print(pkg, 'version', mod.__version__)
-                else:
-                    print(pkg, 'version not available')
-
+                versions.append(mod.__version__)
             except ImportError as e:
-                print(pkg, 'is not installed')
+                versions.append('not installed')
 
             except Exception as e:
-                print(pkg, 'version check failed:', e)
+                versions.append('version check failed: {}'.format(e))
 
         ## PyTrilinos
+        packages.append('PyTrilinos')
         try:
             import PyTrilinos
-            print(PyTrilinos.version())
+            versions.append(PyTrilinos.version())
         except ImportError as e:
-            print('PyTrilinos is not installed')
+            versions.append('not installed')
         except Exception as e:
-            print('PyTrilinos version check failed:', e)
+            versions.append('version check failed: {}'.format(e))
 
         ## Mayavi uses a non-standard approach for storing its version number.
+        packages.append('mayavi')
         try:
             from mayavi.__version__ import __version__ as mayaviversion
-            print('mayavi version', mayaviversion)
+            versions.append(mayaviversion)
         except ImportError as e:
             try:
                 from enthought.mayavi.__version__ import __version__ as mayaviversion
-                print('enthought.mayavi version', mayaviversion)
+                versions.append(mayaviversion)
             except ImportError as e:
-                print('enthought.mayavi is not installed')
-            except Exception as e:
-                print('enthought.mayavi version check failed:', e)
+                versions.append('not installed')
         except Exception as e:
-            print('mayavi version check failed:', e)
+            versions.append('version check failed: {}'.format(e))
 
         ## Gmsh version
+        packages.append('gmsh')
         try:
             from fipy.meshes.gmshMesh import gmshVersion
             gmshversion = gmshVersion()
             if gmshversion is None:
-                print('gmsh is not installed')
+                versions.append('not installed')
             else:
-                print('gmsh version', gmshversion)
+                versions.append(gmshversion)
         except Exception as e:
-            print('gmsh version check failed:', e)
+            versions.append('version check failed: {}'.format(e))
+
+        packages.append("solver")
+        try:
+            from fipy.solvers import solver
+            versions.append(solver)
+        except Exception as e:
+            versions.append(str(e))
+
+        print()
+        package_width = max(len(word) for word in packages)
+        for package, version in zip(packages, versions):
+            print("  ".join((package.ljust(package_width), version)))
+        print()
 
     def run_tests(self):
         import sys


### PR DESCRIPTION
Add python interpreter and indicate which solver suite is in use.

Nicer output, e.g.
```
python      3.6.11 | packaged by conda-forge | (default, Jul 28 2020, 23:03:33) | [GCC Clang 10.0.1 ]
fipy        3.4.2.1+3.gb04cdf949
numpy       1.19.1
pysparse    not installed
scipy       1.5.2
matplotlib  3.3.0
mpi4py      3.0.3
petsc4py    3.13.0
pyamgx      not installed
PyTrilinos  not installed
mayavi      4.7.1
gmsh        3.0.6
solver      petsc
```