### PR TITLE
Replace deprecated numpy types

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,19 +29,19 @@ environment:
       FIPY_SOLVERS: scipy
 
 #    - TARGET_ARCH: x86
-#      CONDA_PY: 39
-#      CONDA_INSTALL_LOCN: C:\\Miniconda39
+#      CONDA_PY: 38
+#      CONDA_INSTALL_LOCN: C:\\Miniconda38
 #      FIPY_SOLVERS: scipy
 
     - TARGET_ARCH: x64
-      CONDA_PY: 39
-      CONDA_INSTALL_LOCN: C:\\Miniconda39-x64
+      CONDA_PY: 38
+      CONDA_INSTALL_LOCN: C:\\Miniconda38-x64
       FIPY_SOLVERS: scipy
 
 matrix:
   exclude:
     - image: Visual Studio 2015
-      CONDA_PY: 39
+      CONDA_PY: 38
 
     - image: Visual Studio 2019
       CONDA_PY: 27
@@ -77,7 +77,7 @@ install:
 
     # Configure the VM.
     - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "27" conda.exe install --quiet --name root python=2.7 fipy
-    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "39" conda.exe install --quiet --name root python=3 fipy gmsh
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "38" conda.exe install --quiet --name root python=3 fipy gmsh
     - cmd: conda.exe remove --quiet --force fipy
     # FIXME: fipy recipe on conda-forge doesn't have gmsh compatible with Python 2.7
     - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,19 +29,19 @@ environment:
       FIPY_SOLVERS: scipy
 
 #    - TARGET_ARCH: x86
-#      CONDA_PY: 36
-#      CONDA_INSTALL_LOCN: C:\\Miniconda36
+#      CONDA_PY: 39
+#      CONDA_INSTALL_LOCN: C:\\Miniconda39
 #      FIPY_SOLVERS: scipy
 
     - TARGET_ARCH: x64
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+      CONDA_PY: 39
+      CONDA_INSTALL_LOCN: C:\\Miniconda39-x64
       FIPY_SOLVERS: scipy
 
 matrix:
   exclude:
     - image: Visual Studio 2015
-      CONDA_PY: 36
+      CONDA_PY: 39
 
     - image: Visual Studio 2019
       CONDA_PY: 27
@@ -77,7 +77,7 @@ install:
 
     # Configure the VM.
     - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "27" conda.exe install --quiet --name root python=2.7 fipy
-    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "36" conda.exe install --quiet --name root python>3 fipy gmsh
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "39" conda.exe install --quiet --name root python=3 fipy gmsh
     - cmd: conda.exe remove --quiet --force fipy
     # FIXME: fipy recipe on conda-forge doesn't have gmsh compatible with Python 2.7
     - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,6 +72,7 @@ install:
     - cmd: conda.exe config --set always_yes yes
     - cmd: conda.exe config --set changeps1 no
     - cmd: conda.exe config --remove channels defaults
+    - cmd: if "%CONDA_PY%" == "27" conda.exe config --add channels defaults
     - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,7 +72,6 @@ install:
     - cmd: conda.exe config --set always_yes yes
     - cmd: conda.exe config --set changeps1 no
     - cmd: conda.exe config --remove channels defaults
-    - cmd: conda.exe config --add channels defaults
     - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.

--- a/fipy/tests/test.py
+++ b/fipy/tests/test.py
@@ -34,6 +34,8 @@ class DeprecationErroringTestProgram(unittest.TestProgram):
             warnings.filterwarnings(action="default", category=DeprecationWarning,
                                     message="invalid escape sequence.*")
 
+            # Don't raise errors in skfmm.pfmm
+            # due to deprecation of np.int in NumPy 1.20
             warnings.filterwarnings(action="default", category=DeprecationWarning,
                                     message="`np\.int` is a deprecated alias for the builtin `int`.*",
                                     module="skfmm\.pfmm")

--- a/fipy/tests/test.py
+++ b/fipy/tests/test.py
@@ -34,6 +34,10 @@ class DeprecationErroringTestProgram(unittest.TestProgram):
             warnings.filterwarnings(action="default", category=DeprecationWarning,
                                     message="invalid escape sequence.*")
 
+            warnings.filterwarnings(action="default", category=DeprecationWarning,
+                                    message="`np\.int` is a deprecated alias for the builtin `int`.*",
+                                    module="skfmm\.pfmm")
+
             super(DeprecationErroringTestProgram, self).runTests()
 
 class test(_test):

--- a/fipy/tests/test.py
+++ b/fipy/tests/test.py
@@ -40,6 +40,12 @@ class DeprecationErroringTestProgram(unittest.TestProgram):
                                     message="`np\.int` is a deprecated alias for the builtin `int`.*",
                                     module="skfmm\.pfmm")
 
+            # Don't raise errors in tvtk.array_handler
+            # due to deprecation of dtype conversion of np.character
+            warnings.filterwarnings(action="default", category=DeprecationWarning,
+                                    message="Converting `np\.character` to a dtype is deprecated..*",
+                                    module="tvtk\.array_handler")
+
             super(DeprecationErroringTestProgram, self).runTests()
 
 class test(_test):

--- a/fipy/tests/test.py
+++ b/fipy/tests/test.py
@@ -40,12 +40,6 @@ class DeprecationErroringTestProgram(unittest.TestProgram):
                                     message="`np\.int` is a deprecated alias for the builtin `int`.*",
                                     module="skfmm\.pfmm")
 
-            # Don't raise errors in tvtk.array_handler
-            # due to deprecation of dtype conversion of np.character
-            warnings.filterwarnings(action="default", category=DeprecationWarning,
-                                    message="Converting `np\.character` to a dtype is deprecated..*",
-                                    module="tvtk\.array_handler")
-
             super(DeprecationErroringTestProgram, self).runTests()
 
 class test(_test):

--- a/fipy/tests/test.py
+++ b/fipy/tests/test.py
@@ -46,12 +46,6 @@ class DeprecationErroringTestProgram(unittest.TestProgram):
                                     message="Converting `np\.character` to a dtype is deprecated..*",
                                     module="tvtk\.array_handler")
 
-            # Don't raise errors in tvtk.tvtk_base
-            # due to deprecation of TraitPrefixMap
-            warnings.filterwarnings(action="default", category=DeprecationWarning,
-                                    message="'TraitPrefixMap' trait handler has been deprecated.*",
-                                    module="tvtk\.tvtk_base")
-
             super(DeprecationErroringTestProgram, self).runTests()
 
 class test(_test):

--- a/fipy/tests/test.py
+++ b/fipy/tests/test.py
@@ -46,6 +46,12 @@ class DeprecationErroringTestProgram(unittest.TestProgram):
                                     message="Converting `np\.character` to a dtype is deprecated..*",
                                     module="tvtk\.array_handler")
 
+            # Don't raise errors in tvtk.tvtk_base
+            # due to deprecation of TraitPrefixMap
+            warnings.filterwarnings(action="default", category=DeprecationWarning,
+                                    message="'TraitPrefixMap' trait handler has been deprecated.*",
+                                    module="tvtk\.tvtk_base")
+
             super(DeprecationErroringTestProgram, self).runTests()
 
 class test(_test):

--- a/fipy/variables/variable.py
+++ b/fipy/variables/variable.py
@@ -507,7 +507,7 @@ class Variable(object):
                 else:
                     mask = constraint.where
                     if not hasattr(mask, 'dtype') or mask.dtype != bool:
-                        mask = numerix.array(mask, dtype=numerix.NUMERIX.bool)
+                        mask = numerix.array(mask, dtype=bool)
 
                     if 0 not in value.shape:
                         try:


### PR DESCRIPTION
Recent NumPy versions (~1.20) raise a number of deprecation warnings:
- "`np.bool` is a deprecated alias for the builtin `bool`" in `fipy.variables.variable`
- "`np.int` is a deprecated alias for the builtin `int`" in `skfmm`
- "Converting `np.character` to a dtype is deprecated" in `tvtk`