### PR TITLE
Speed up conda environment creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ commands:
           paths:
             - /opt/conda
             - /root/.cache/pip
-          key: v13-dependencies-{{ arch }}-<< parameters.condaenv >>
+          key: v14-dependencies-{{ arch }}-<< parameters.condaenv >>
 
   restore_conda_cache:
     description: "Restore cache holding conda and pip"
@@ -160,9 +160,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-          - v13-dependencies-{{ arch }}-<< parameters.condaenv >>
+          - v14-dependencies-{{ arch }}-<< parameters.condaenv >>
           # fallback to using the latest cache if no exact match is found
-          - v13-dependencies-
+          - v14-dependencies-
 
   install_dependencies:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,10 +40,11 @@ commands:
       - run:
           name: Create Conda Environment
           command: |
-            conda create -v --quiet --prefix << parameters.condaenv >> --show-channel-urls --channel conda-forge "<< parameters.python >>" << parameters.packages >>
+            conda install --channel conda-forge mamba
+            mamba create -v --quiet --prefix << parameters.condaenv >> --show-channel-urls --channel conda-forge "<< parameters.python >>" << parameters.packages >>
             source activate ~/project/<< parameters.condaenv >>
-            conda install --quiet --show-channel-urls --channel conda-forge gmsh
-            conda remove --quiet --channel conda-forge --force fipy
+            mamba install --quiet --show-channel-urls --channel conda-forge gmsh
+            mamba remove --quiet --channel conda-forge --force fipy
             pip install scikit-fmm
 
   test_fipy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,9 @@ commands:
       - run:
           name: Create Conda Environment
           command: |
-            conda create -v --quiet --prefix << parameters.condaenv >> --show-channel-urls --channel conda-forge "<< parameters.python >>" << parameters.packages >> gmsh
+            conda create -v --quiet --prefix << parameters.condaenv >> --show-channel-urls --channel conda-forge "<< parameters.python >>" << parameters.packages >>
             source activate ~/project/<< parameters.condaenv >>
+            conda install --quiet --show-channel-urls --channel conda-forge gmsh
             conda remove --quiet --channel conda-forge --force fipy
             pip install scikit-fmm
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,7 +434,7 @@ jobs:
           name: Lint
           command: |
             source activate ~/project/<< parameters.condaenv >>
-            conda install --channel conda-forge black
+            mamba install --channel conda-forge black
             black --target-version py27 --fast --diff --check setup.py
 
   pyspelling:
@@ -458,7 +458,7 @@ jobs:
           name: Spell Check
           command: |
             source activate ~/project/<< parameters.condaenv >>
-            conda install --channel conda-forge hunspell
+            mamba install --channel conda-forge hunspell
             pip install pyspelling
             wget -O en_US.aff  https://cgit.freedesktop.org/libreoffice/dictionaries/plain/en/en_US.aff?id=a4473e06b56bfe35187e302754f6baaa8d75e54f
             wget -O en_US.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/en/en_US.dic?id=a4473e06b56bfe35187e302754f6baaa8d75e54f
@@ -489,10 +489,10 @@ jobs:
           name: install sphinx
           command: |
             source activate ~/project/<< parameters.condaenv >>
-            conda install --channel conda-forge sphinx future
+            mamba install --channel conda-forge sphinx future
             pip install 'sphinxcontrib-bibtex<=0.4.2'
             pip install numpydoc
-            conda install --channel conda-forge matplotlib pandas imagemagick
+            mamba install --channel conda-forge matplotlib pandas imagemagick
 
       - build_html_docs:
           condaenv: << parameters.condaenv >>
@@ -522,10 +522,10 @@ jobs:
           name: install sphinx
           command: |
             source activate ~/project/<< parameters.condaenv >>
-            conda install --channel conda-forge sphinx future
+            mamba install --channel conda-forge sphinx future
             pip install sphinxcontrib-bibtex
             pip install numpydoc
-            conda install --channel conda-forge matplotlib pandas imagemagick
+            mamba install --channel conda-forge matplotlib pandas imagemagick
 
       - run:
           name: Install LaTeX

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,6 @@ commands:
       - run:
           name: Create Conda Environment
           command: |
-            conda install --channel conda-forge mamba
             mamba create -v --quiet --prefix << parameters.condaenv >> --show-channel-urls --channel conda-forge "<< parameters.python >>" << parameters.packages >>
             source activate ~/project/<< parameters.condaenv >>
             mamba remove --quiet --channel conda-forge --force fipy
@@ -174,6 +173,7 @@ commands:
             apt-get --yes install build-essential
             conda config --set always_yes yes --set changeps1 no
             conda config --remove channels defaults
+            conda install --channel conda-forge mamba
 
   remove_extracted_conda_packages:
     description: "force conda to download packages into the cache and then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ commands:
             conda install --channel conda-forge mamba
             mamba create -v --quiet --prefix << parameters.condaenv >> --show-channel-urls --channel conda-forge "<< parameters.python >>" << parameters.packages >>
             source activate ~/project/<< parameters.condaenv >>
-            mamba install --quiet --show-channel-urls --channel conda-forge gmsh
             mamba remove --quiet --channel conda-forge --force fipy
             pip install scikit-fmm
 
@@ -250,7 +249,7 @@ jobs:
     steps:
       - install_conda_packages:
           python:   "python=2.7"
-          packages: "fipy \"traitsui<7.0.0\""
+          packages: "fipy \"traitsui<7.0.0\" \"gmsh<4.0\""
           condaenv: "test-environment-27"
 
   conda3_env:
@@ -259,7 +258,7 @@ jobs:
     steps:
       - install_conda_packages:
           python:   "python=3"
-          packages: "fipy pytrilinos"
+          packages: "fipy pytrilinos gmsh"
           condaenv: "test-environment-36"
 
   pip_env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,9 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda create --quiet --name test-environment --show-channel-urls --channel conda-forge python=$TRAVIS_PYTHON_VERSION fipy gmsh pytrilinos;
+  - conda create --quiet --name test-environment --show-channel-urls --channel conda-forge python=$TRAVIS_PYTHON_VERSION fipy pytrilinos;
   - source activate test-environment
+  - conda install --quiet --show-channel-urls --channel conda-forge gmsh;
   - conda remove --quiet --channel conda-forge --force fipy
   - if [[ $PY3K -eq 0 ]]; then
       conda install --channel conda-forge "traitsui<7.0.0";

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,13 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda create --quiet --name test-environment --show-channel-urls --channel conda-forge python=$TRAVIS_PYTHON_VERSION fipy pytrilinos;
+  - conda install --channel conda-forge mamba
+  - mamba create --quiet --name test-environment --show-channel-urls --channel conda-forge python=$TRAVIS_PYTHON_VERSION fipy pytrilinos;
   - source activate test-environment
-  - conda install --quiet --show-channel-urls --channel conda-forge gmsh;
-  - conda remove --quiet --channel conda-forge --force fipy
+  - mamba install --quiet --show-channel-urls --channel conda-forge gmsh;
+  - mamba remove --quiet --channel conda-forge --force fipy
   - if [[ $PY3K -eq 0 ]]; then
-      conda install --channel conda-forge "traitsui<7.0.0";
+      mamba install --channel conda-forge "traitsui<7.0.0";
     fi
   # Useful for debugging any issues with conda
   - conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,11 @@ before_install:
   - conda install --channel conda-forge mamba
   - mamba create --quiet --name test-environment --show-channel-urls --channel conda-forge python=$TRAVIS_PYTHON_VERSION fipy pytrilinos;
   - source activate test-environment
-  - mamba install --quiet --show-channel-urls --channel conda-forge gmsh;
   - mamba remove --quiet --channel conda-forge --force fipy
   - if [[ $PY3K -eq 0 ]]; then
-      mamba install --channel conda-forge "traitsui<7.0.0";
+      mamba install --channel conda-forge "traitsui<7.0.0" "gmsh<4.0";
+    else
+      mamba install --channel conda-forge gmsh;
     fi
   # Useful for debugging any issues with conda
   - conda info -a

--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -120,7 +120,10 @@ Recommended Method
 
   .. note::
 
-     conda_ can be quite slow to resolve all dependencies when performing
+     conda_ can be
+     `quite <https://www.anaconda.com/blog/understanding-and-improving-condas-performance>`_
+     `slow <https://medium.com/@marius.v.niekerk/conda-metachannel-f962241c9437>`_
+     to resolve all dependencies when performing
      an installation.  You may wish to consider using the alternative
      mamba_ installation manager to speed things up.
 

--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -120,6 +120,12 @@ Recommended Method
 
   .. note::
 
+     conda_ can be quite slow to resolve all dependencies when performing
+     an installation.  You may wish to consider using the alternative
+     mamba_ installation manager to speed things up.
+
+  .. note::
+
      On Linux_ and `Mac OS X`_, you should have a pretty complete system
      to run and visualize :term:`FiPy` simulations. On Windows_, there
      are fewer packages available via conda_, particularly amongst the
@@ -141,6 +147,7 @@ Recommended Method
 .. _Windows: http://www.microsoft.com/windows/
 .. |CondaForge|    image:: https://anaconda.org/conda-forge/fipy/badges/installer/conda.svg
 .. _CondaForge:    https://anaconda.org/conda-forge/fipy
+.. _mamba: https://github.com/mamba-org/mamba
 
 
 --------------


### PR DESCRIPTION
Conda's opaque package resolution scheme causes us to have
extremely long environment solves, followed by getting an
ancient version of FiPy.

We want *new* fipy, and can accept an old gmsh,
but how to tell conda that?

Fixes #800