### PR TITLE
Issue858 pysparse ci failure

### DIFF
--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -11,12 +11,6 @@ jobs:
   - job: Test
     strategy:
       matrix:
-        linux-py27-pysparse:
-          image: ubuntu-latest
-          python_version: 2.7
-          conda_packages: '"traitsui<7.0.0" "gmsh<4.0"'
-          FIPY_SOLVERS: pysparse
-          MPIRUN:
         linux-py39-petsc:
           image: ubuntu-latest
           python_version: 3.9

--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -164,12 +164,6 @@ stages:
             conda_packages: 'gmsh pytrilinos'
             FIPY_SOLVERS: trilinos
             MPIRUN: 'mpirun -np 2'
-          windows-py27-pysparse:
-            image: windows-latest
-            python_version: 2.7
-            conda_packages: '"traitsui<7.0.0" "gmsh<4.0"'
-            FIPY_SOLVERS: pysparse
-            MPIRUN:
           windows-py3k-scipy:
             image: windows-latest
             python_version: 3.10

--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -83,6 +83,12 @@ jobs:
           conda_packages: 'gmsh pytrilinos'
           FIPY_SOLVERS: trilinos
           MPIRUN: 'mpirun -np 2'
+        windows-py27-pysparse:
+          image: windows-latest
+          python_version: 2.7
+          conda_packages: '"traitsui<7.0.0" "gmsh<4.0"'
+          FIPY_SOLVERS: pysparse
+          MPIRUN:
         windows-py39-scipy:
           image: windows-latest
           python_version: 3.9


### PR DESCRIPTION
As reported in #858, pysparse on linux doesn't run. Not worth trying to sort out bit-rot. 

It still runs on macOS for now.

Try running on Windows.