### PR TITLE
WIP: Propogate boundary conditions to old values

### DIFF
--- a/fipy/variables/cellVariable.py
+++ b/fipy/variables/cellVariable.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 __docformat__ = 'restructuredtext'
 
 from .meshVariable import _MeshVariable
+from .variable import Variable
 from ..solvers import _MeshMatrix
 from ..tools import numerix
 from ..tools.decorators import deprecate
@@ -478,7 +479,12 @@ class CellVariable(_MeshVariable):
             raise AssertionError('The updateOld method requires the CellVariable to have an old value. Set hasOld to True when instantiating the CellVariable.')
         else:
             self._old.value = self.value.copy()
-
+            
+            # Also propogate constraints:
+            if hasattr(self._old, 'faceConstraints'):
+                for n in range(len(self.faceConstraints)):
+                    self._old.faceConstraints[n].value.setValue(self.faceConstraints[n].value)
+               
     def _resetToOld(self):
         if self._old is not None:
             self.value = (self._old.value)
@@ -584,19 +590,25 @@ class CellVariable(_MeshVariable):
         """
         from fipy.boundaryConditions.constraint import Constraint
         if not isinstance(value, Constraint):
-            value = Constraint(value=value, where=where)
+            constraint = Constraint(value=value, where=where)
 
-        if numerix.shape(value.where)[-1] == self.mesh.numberOfFaces:
+        if numerix.shape(constraint.where)[-1] == self.mesh.numberOfFaces:
 
             if not hasattr(self, 'faceConstraints'):
                 self.faceConstraints = []
-            self.faceConstraints.append(value)
-            self._requires(value.value)
-            # self._requires(value.where) ???
+                
+            self.faceConstraints.append(constraint)
+            
+            if self._old is not None:
+                value_old = Variable(value = value)
+                self._old.constrain(value=value_old, where=where)
+                
+            self._requires(constraint.value)
+            # self._requires(constraint.where) ???
             self._markStale()
         else:
 ##            _MeshVariable.constrain(value, where)
-            super(CellVariable, self).constrain(value, where)
+            super(CellVariable, self).constrain(constraint, where)
 
     def release(self, constraint):
         """Remove `constraint` from `self`


### PR DESCRIPTION
Draft WIP:

Currently fipy does not apply boundary conditions to the old values stored in variables. This means that when you compute some metrics (like the time derivative of a quantity on the boundary), you don't get the expected answer.

I'm making this draft pull request to start a conversation and see if this is something that would be helpful to contribute upstream. I've been using these changes locally for a while.