### PR TITLE
Get CI working again

### DIFF
--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -234,6 +234,10 @@ stages:
         displayName: Install LaTeX
 
       - bash: |
+          conda env export --name myEnvironment
+        displayName: Environment
+
+      - bash: |
           source activate myEnvironment
           export ETS_TOOLKIT=null
           python setup.py build_docs --html
@@ -290,6 +294,10 @@ stages:
           check-wheel-contents dist/*.whl
         displayName: Build wheel
         condition: startsWith(variables.image, 'ubuntu')
+
+      - bash: |
+          conda env export --name myEnvironment
+        displayName: Environment
 
       - bash: |
           source activate myEnvironment

--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -42,7 +42,7 @@ stages:
           pip install pyspelling
         displayName: Install pip packages
 
-#       - bash: |
+      - bash: |
           wget -O en_US.aff  https://cgit.freedesktop.org/libreoffice/dictionaries/plain/en/en_US.aff?id=a4473e06b56bfe35187e302754f6baaa8d75e54f
           wget -O en_US.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/en/en_US.dic?id=a4473e06b56bfe35187e302754f6baaa8d75e54f
         displayName: Obtain dictionaries

--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -137,7 +137,7 @@ stages:
           macos-py27-pysparse:
             image: macos-latest
             python_version: 2.7
-            conda_packages: ''numpy scipy matplotlib-base future packaging pysparse mayavi "traitsui<7.0.0" "gmsh<4.0"'
+            conda_packages: 'numpy scipy matplotlib-base future packaging pysparse mayavi "traitsui<7.0.0" "gmsh<4.0"'
             FIPY_SOLVERS: pysparse
             MPIRUN:
           macos-py3k-petsc:

--- a/.azure/pipelines.yml
+++ b/.azure/pipelines.yml
@@ -34,7 +34,7 @@ stages:
       steps:
       - template: templates/install.yml
         parameters:
-          python_version: 3.10
+          python_version: 3
           conda_packages: 'hunspell'
 
       - bash: |
@@ -42,7 +42,7 @@ stages:
           pip install pyspelling
         displayName: Install pip packages
 
-      - bash: |
+#       - bash: |
           wget -O en_US.aff  https://cgit.freedesktop.org/libreoffice/dictionaries/plain/en/en_US.aff?id=a4473e06b56bfe35187e302754f6baaa8d75e54f
           wget -O en_US.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/en/en_US.dic?id=a4473e06b56bfe35187e302754f6baaa8d75e54f
         displayName: Obtain dictionaries
@@ -62,7 +62,7 @@ stages:
       steps:
       - template: templates/install.yml
         parameters:
-          python_version: 3.10
+          python_version: 3
           conda_packages: 'numpy'
 
       - bash: |
@@ -85,7 +85,7 @@ stages:
       steps:
       - template: templates/install.yml
         parameters:
-          python_version: 3.10
+          python_version: 3
           conda_packages: 'numpy'
 
       - bash: |
@@ -106,74 +106,74 @@ stages:
         matrix:
           linux-py3k-petsc:
             image: ubuntu-latest
-            python_version: 3.10
-            conda_packages: gmsh
+            python_version: 3
+            conda_packages: 'numpy scipy matplotlib-base future packaging mpich mpi4py petsc4py mayavi "gmsh <4.0|>=4.5.2"'
             FIPY_SOLVERS: petsc
             MPIRUN:
           linux-py3k-petsc-parallel:
             image: ubuntu-latest
-            python_version: 3.10
-            conda_packages: gmsh
+            python_version: 3
+            conda_packages: 'numpy scipy matplotlib-base future packaging mpich mpi4py petsc4py mayavi "gmsh <4.0|>=4.5.2"'
             FIPY_SOLVERS: petsc
             MPIRUN: 'mpirun -np 2'
           linux-py3k-scipy:
             image: ubuntu-latest
-            python_version: 3.10
-            conda_packages: gmsh
+            python_version: 3
+            conda_packages: 'numpy scipy matplotlib-base future packaging mayavi "gmsh <4.0|>=4.5.2"'
             FIPY_SOLVERS: scipy
             MPIRUN:
-          linux-py37-trilinos:
+          linux-py3k-trilinos:
             image: ubuntu-latest
-            python_version: 3.7
-            conda_packages: 'gmsh pytrilinos'
+            python_version: 3
+            conda_packages: 'numpy scipy matplotlib-base future packaging mpich mpi4py pytrilinos mayavi "gmsh <4.0|>=4.5.2"'
             FIPY_SOLVERS: trilinos
             MPIRUN:
-          linux-py37-trilinos-parallel:
+          linux-py3k-trilinos-parallel:
             image: ubuntu-latest
-            python_version: 3.7
-            conda_packages: 'gmsh pytrilinos'
+            python_version: 3
+            conda_packages: 'numpy scipy matplotlib-base future packaging mpich mpi4py pytrilinos mayavi "gmsh <4.0|>=4.5.2"'
             FIPY_SOLVERS: trilinos
             MPIRUN: 'mpirun -np 2'
           macos-py27-pysparse:
             image: macos-latest
             python_version: 2.7
-            conda_packages: '"traitsui<7.0.0" "gmsh<4.0"'
+            conda_packages: ''numpy scipy matplotlib-base future packaging pysparse mayavi "traitsui<7.0.0" "gmsh<4.0"'
             FIPY_SOLVERS: pysparse
             MPIRUN:
           macos-py3k-petsc:
             image: macos-latest
-            python_version: 3.10
-            conda_packages: gmsh
+            python_version: 3
+            conda_packages: 'numpy scipy matplotlib-base future packaging mpich mpi4py petsc4py mayavi "gmsh <4.0|>=4.5.2"'
             FIPY_SOLVERS: petsc
             MPIRUN:
           macos-py3k-petsc-parallel:
             image: macos-latest
-            python_version: 3.10
-            conda_packages: gmsh
+            python_version: 3
+            conda_packages: 'numpy scipy matplotlib-base future packaging mpich mpi4py petsc4py mayavi "gmsh <4.0|>=4.5.2"'
             FIPY_SOLVERS: petsc
             MPIRUN: 'mpirun -np 2'
           macos-py3k-scipy:
             image: macos-latest
-            python_version: 3.10
-            conda_packages: gmsh
+            python_version: 3
+            conda_packages: 'numpy scipy matplotlib-base future packaging mayavi "gmsh <4.0|>=4.5.2"'
             FIPY_SOLVERS: scipy
             MPIRUN:
-          macos-py37-trilinos:
+          macos-py3k-trilinos:
             image: macos-latest
-            python_version: 3.7
-            conda_packages: 'gmsh pytrilinos'
+            python_version: 3
+            conda_packages: 'numpy scipy matplotlib-base future packaging mpich mpi4py pytrilinos mayavi "gmsh <4.0|>=4.5.2"'
             FIPY_SOLVERS: trilinos
             MPIRUN:
-          macos-py37-trilinos-parallel:
+          macos-py3k-trilinos-parallel:
             image: macos-latest
-            python_version: 3.7
-            conda_packages: 'gmsh pytrilinos'
+            python_version: 3
+            conda_packages: 'numpy scipy matplotlib-base future packaging mpich mpi4py pytrilinos mayavi "gmsh <4.0|>=4.5.2"'
             FIPY_SOLVERS: trilinos
             MPIRUN: 'mpirun -np 2'
           windows-py3k-scipy:
             image: windows-latest
-            python_version: 3.10
-            conda_packages: gmsh
+            python_version: 3
+            conda_packages: 'numpy scipy matplotlib-base future packaging mayavi "gmsh <4.0|>=4.5.2"'
             FIPY_SOLVERS: scipy
             MPIRUN:
 
@@ -214,8 +214,8 @@ stages:
       steps:
       - template: templates/install.yml
         parameters:
-          python_version: 3.10
-          conda_packages: 'sphinx future matplotlib pandas imagemagick'
+          python_version: 3
+          conda_packages: 'numpy scipy matplotlib future packaging mpich mpi4py petsc4py mayavi "gmsh <4.0|>=4.5.2" sphinx pandas imagemagick'
 
       - bash: |
           source activate myEnvironment
@@ -260,13 +260,13 @@ stages:
           unix:
             image: ubuntu-latest
             python_version: 3.10
-            conda_packages: gmsh
+            conda_packages: 'numpy scipy matplotlib-base future packaging mpich mpi4py petsc4py mayavi "gmsh <4.0|>=4.5.2"'
             FIPY_SOLVERS: petsc
             MPIRUN:
           windows:
             image: windows-latest
             python_version: 3.10
-            conda_packages: gmsh
+            conda_packages: 'numpy scipy matplotlib-base future packaging mayavi "gmsh <4.0|>=4.5.2"'
             FIPY_SOLVERS: scipy
             MPIRUN:
 

--- a/.azure/templates/install.yml
+++ b/.azure/templates/install.yml
@@ -44,13 +44,13 @@ steps:
   - bash: |
       if [[ ${{ parameters.python_version }} == "2.7" ]]; then
         # mamba doesn't work in Py2.7; do mamba installs from base
-        mamba install --quiet --name myEnvironment --channel conda-forge --only-deps python=${{ parameters.python_version }} fipy
         mamba install --quiet --name myEnvironment --channel conda-forge python=${{ parameters.python_version }} ${{ parameters.conda_packages }}
+        mamba install --quiet --name myEnvironment --channel conda-forge --only-deps python=${{ parameters.python_version }} fipy
       else
         # do mamba installs from environment on Py3k
         source activate myEnvironment
-        mamba install --quiet --channel conda-forge --only-deps python=${{ parameters.python_version }} fipy
         mamba install --quiet --channel conda-forge python=${{ parameters.python_version }} ${{ parameters.conda_packages }}
+        mamba install --quiet --channel conda-forge --only-deps python=${{ parameters.python_version }} fipy
       fi
     displayName: Install Anaconda packages
 

--- a/.azure/templates/install.yml
+++ b/.azure/templates/install.yml
@@ -45,12 +45,10 @@ steps:
       if [[ ${{ parameters.python_version }} == "2.7" ]]; then
         # mamba doesn't work in Py2.7; do mamba installs from base
         mamba install --quiet --name myEnvironment --channel conda-forge python=${{ parameters.python_version }} ${{ parameters.conda_packages }}
-        mamba install --quiet --name myEnvironment --channel conda-forge --only-deps python=${{ parameters.python_version }} fipy
       else
         # do mamba installs from environment on Py3k
         source activate myEnvironment
         mamba install --quiet --channel conda-forge python=${{ parameters.python_version }} ${{ parameters.conda_packages }}
-        mamba install --quiet --channel conda-forge --only-deps python=${{ parameters.python_version }} fipy
       fi
     displayName: Install Anaconda packages
 

--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -78,6 +78,17 @@ Recommended Method
      :term:`Gmsh` is an optional package because some versions are
      incompatible with :term:`FiPy`, so it must be requested explicitly.
 
+  .. note::
+
+     The `fipy conda-forge`_ package is a convenience. You may choose to
+     install packages explicitly, e.g.,::
+
+       $ conda create --name <MYFIPYENV> --channel conda-forge python=3 numpy scipy matplotlib-base future packaging mpich mpi4py petsc4py mayavi "gmsh <4.0|>=4.5.2"
+
+     or
+
+       $ conda create --name <MYFIPYENV> --channel conda-forge python=2.7 numpy scipy matplotlib-base future packaging pysparse mayavi "traitsui<7.0.0" "gmsh<4.0"
+
   .. attention::
 
      Windows x86_64 is fully supported, but this does not work on
@@ -150,7 +161,7 @@ Recommended Method
 .. _Windows: http://www.microsoft.com/windows/
 .. |CondaForge|    image:: https://anaconda.org/conda-forge/fipy/badges/installer/conda.svg
 .. _CondaForge:    https://anaconda.org/conda-forge/fipy
-.. _mamba: https://github.com/mamba-org/mamba
+.. _mamba: https://mamba.readthedocs.io/
 
 
 --------------

--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -162,6 +162,7 @@ Recommended Method
 .. |CondaForge|    image:: https://anaconda.org/conda-forge/fipy/badges/installer/conda.svg
 .. _CondaForge:    https://anaconda.org/conda-forge/fipy
 .. _mamba: https://mamba.readthedocs.io/
+.. _fipy conda-forge: https://anaconda.org/conda-forge/fipy
 
 
 --------------

--- a/documentation/_themes/nist/basic_layout.html
+++ b/documentation/_themes/nist/basic_layout.html
@@ -94,7 +94,7 @@
 {%- endmacro %}
 
 {%- macro css() %}
-    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto('_static/' + styles[-1], 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
     {%- for css in css_files %}
       {%- if css|attr("filename") %}

--- a/fipy/matrices/trilinosMatrix.py
+++ b/fipy/matrices/trilinosMatrix.py
@@ -477,7 +477,10 @@ class _TrilinosMatrix(_SparseMatrix):
     def numpyArray(self):
         import tempfile
         import os
-        from scipy.io import mmio
+        try:
+            from scipy.io import mmread
+        except ImportError:
+            from scipy.io.mmio import mmread
         from fipy.tools import parallelComm
 
         if parallelComm.procID == 0:
@@ -490,7 +493,7 @@ class _TrilinosMatrix(_SparseMatrix):
         self.exportMmf(mtxName)
 
         parallelComm.Barrier()
-        mtx = mmio.mmread(mtxName)
+        mtx = mmread(mtxName)
         parallelComm.Barrier()
 
         if parallelComm.procID == 0:

--- a/fipy/solvers/trilinos/__init__.py
+++ b/fipy/solvers/trilinos/__init__.py
@@ -34,15 +34,18 @@ def _dealWithTrilinosImportPathologies():
 
     from PyTrilinos import Epetra
 
-    import platform
-    if platform.dist()[0] == 'debian':
-        import PyTrilinos
-        if '10.0.4' in PyTrilinos.version():
-            # The package mpi4py is a required package if you are using
-            # Trilinos on a Debian platform with Trilinos version 10.0.4 due to
-            # a Trilinos bug (see <https://github.com/usnistgov/fipy/issues/301>).
+    try:
+        import platform
+        if platform.dist()[0] == 'debian':
+            import PyTrilinos
+            if '10.0.4' in PyTrilinos.version():
+                # The package mpi4py is a required package if you are using
+                # Trilinos on a Debian platform with Trilinos version 10.0.4 due to
+                # a Trilinos bug (see <https://github.com/usnistgov/fipy/issues/301>).
 
-            from mpi4py import MPI
+                from mpi4py import MPI
+    except:
+        pass
 
 _dealWithTrilinosImportPathologies()
 

--- a/fipy/tests/test.py
+++ b/fipy/tests/test.py
@@ -45,7 +45,7 @@ class DeprecationErroringTestProgram(unittest.TestProgram):
             # raised in Python 3.7, but not newer
             # (combination of PyTrilinos and Gmsh(?) forces this old configuration)
             warnings.filterwarnings(action="default", category=DeprecationWarning,
-                                    message="Deprecated call to `pkg_resources.declare_namespace('scikits')")
+                                    message="Deprecated call to `pkg_resources\.declare_namespace('scikits').*")
 
             super(DeprecationErroringTestProgram, self).runTests()
 

--- a/fipy/tests/test.py
+++ b/fipy/tests/test.py
@@ -40,6 +40,13 @@ class DeprecationErroringTestProgram(unittest.TestProgram):
                                     message="`np\.int` is a deprecated alias for the builtin `int`.*",
                                     module="skfmm\.pfmm")
 
+            # Don't raise errors in scikits.umfpack
+            # due to deprecation of pkg_resources.declare_namespace
+            # raised in Python 3.7, but not newer
+            # (combination of PyTrilinos and Gmsh(?) forces this old configuration)
+            warnings.filterwarnings(action="default", category=DeprecationWarning,
+                                    message="Deprecated call to `pkg_resources.declare_namespace('scikits')")
+
             super(DeprecationErroringTestProgram, self).runTests()
 
 class test(_test):

--- a/fipy/tests/test.py
+++ b/fipy/tests/test.py
@@ -45,7 +45,7 @@ class DeprecationErroringTestProgram(unittest.TestProgram):
             # raised in Python 3.7, but not newer
             # (combination of PyTrilinos and Gmsh(?) forces this old configuration)
             warnings.filterwarnings(action="default", category=DeprecationWarning,
-                                    message="Deprecated call to `pkg_resources\.declare_namespace('scikits').*")
+                                    message="Deprecated call to `pkg_resources\.declare_namespace\('scikits'\)`.*")
 
             super(DeprecationErroringTestProgram, self).runTests()
 

--- a/fipy/variables/operatorVariable.py
+++ b/fipy/variables/operatorVariable.py
@@ -231,6 +231,8 @@ def _OperatorVariableClass(baseClass=object):
                     stack.append(stack.pop() + "(" + ", ".join(args + kwargs) + ")")
                 elif ins.opname == 'LOAD_DEREF':
                     stack.append(ins.argval)
+                elif ins.opname == 'RESUME':
+                    pass
                 elif ins.opcode in self._unop:
                     stack.append(self._unop[ins.opcode] + '(' + stack.pop() + ')')
                 elif ins.opcode in self._binop:

--- a/fipy/variables/operatorVariable.py
+++ b/fipy/variables/operatorVariable.py
@@ -205,6 +205,7 @@ def _OperatorVariableClass(baseClass=object):
 
             for ins in instructions:
                 if ins.opname == 'UNARY_CONVERT':
+                    # Removed in Python 3
                     stack.append("`" + stack.pop() + "`")
                 elif ins.opname == 'BINARY_SUBSCR':
                     stack.append(stack.pop(-2) + "[" + stack.pop() + "]")
@@ -217,18 +218,22 @@ def _OperatorVariableClass(baseClass=object):
                 elif ins.opname == 'LOAD_CONST':
                     stack.append(ins.argval)
                 elif ins.opname in ['LOAD_ATTR', 'LOAD_METHOD']:
+                    # LOAD_METHOD new in Python 3.7
                     stack.append(stack.pop() + "." + ins.argval)
                 elif ins.opname == 'COMPARE_OP':
                     stack.append(stack.pop(-2) + " " + dis.cmp_op[ins.arg] + " " + stack.pop())
                 elif ins.opname == 'LOAD_GLOBAL':
+                    # Changed in Python 3.11
                     stack.append(ins.argval)
                 elif ins.opname == 'LOAD_FAST':
                     stack.append(self.__var(ins.arg, style=style, argDict=argDict, id=id, freshen=freshen))
                 elif ins.opname in ['CALL_FUNCTION', 'CALL_METHOD']:
+                    # Removed in Python 3.11
                     # args are last ins.arg items on stack
                     args, stack = stack[-ins.arg:], stack[:-ins.arg]
                     stack.append(stack.pop() + "(" + ", ".join(args) + ")")
                 elif ins.opname == 'CALL_FUNCTION_KW':
+                    # Removed in Python 3.11
                     kws = list(stack.pop())
                     # args are last ins.arg items on stack
                     args, stack = stack[-ins.arg:], stack[:-ins.arg]
@@ -237,14 +242,19 @@ def _OperatorVariableClass(baseClass=object):
                         kwargs.append(kws.pop() + "=" + args.pop())
                     stack.append(stack.pop() + "(" + ", ".join(args + kwargs) + ")")
                 elif ins.opname == 'LOAD_DEREF':
+                    # Changed in Python 3.11
                     stack.append(op.__closure__[ins.arg-1].cell_contents)
                 elif ins.opname == 'RESUME':
+                    # New in Python 3.11
                     pass
                 elif ins.opname == 'BINARY_OP':
+                    # New in Python 3.11
                     stack.append(stack.pop(-2) + " " + self._binary_op[ins.argval] + " " + stack.pop())
                 elif ins.opname == 'PRECALL':
+                    # New in Python 3.11
                     pass
                 elif ins.opname == 'CALL':
+                    # New in Python 3.11
                     kwargs = [kw + "=" + str(stack.pop()) for kw in kws]
                     positionals = [stack.pop() for _ in range(ins.argval - len(kws))]
                     callable = stack.pop()
@@ -254,22 +264,27 @@ def _OperatorVariableClass(baseClass=object):
                     stack.append(callable + "(" + ", ".join(positionals + kwargs) + ")")
                     kws = []
                 elif ins.opname == 'COPY_FREE_VARS':
+                    # New in Python 3.11
                     pass
                 elif ins.opname == 'KW_NAMES':
+                    # New in Python 3.11
                     kws = op.__code__.co_consts[ins.arg]
                 elif ins.opname == 'BUILD_TUPLE':
                     tpl = tuple(stack.pop() for _ in range(ins.argval))
                     stack.append(tpl)
                 elif ins.opname == 'BUILD_MAP':
+                    # Changed in Python 3.5
                     d = {stack.pop(): stack.pop() for _ in range(ins.argval)}
                     stack.append(d)
                 elif ins.opname == 'DICT_MERGE':
+                    # New in Python 3.9
                     updates = [stack.pop() for _ in range(ins.argval)]
                     d = stack.pop()
                     for u in updates:
                         d.update(u)
                     stack.append(d)
                 elif ins.opname == 'CALL_FUNCTION_EX':
+                    # New in Python 3.6
                     kwargs = [k + "=" + str(v) for k, v in stack.pop().items()]
                     args = [str(v) for v in stack.pop()]
                     stack.append(stack.pop() + "(" + ", ".join(args + kwargs) + ")")

--- a/fipy/variables/operatorVariable.py
+++ b/fipy/variables/operatorVariable.py
@@ -139,6 +139,12 @@ def _OperatorVariableClass(baseClass=object):
                     62: "<<", 63: ">>", 64: "&", 65: "^", 66: "|", 106: "=="
         }
 
+        # introduced in Python 3.11
+        _binary_op = {
+            0: "+", 1: "&", 2: "//", 3: "<<", 4: "@", 5: "*", 6: "%", 7: "|",
+            8: "**", 9: ">>", 10: "-", 11: "/", 12: "^"
+        }
+
         def _py2kInstructions(self, bytecodes, style, argDict, id, freshen):
             def _popIndex():
                 return bytecodes.pop(0) + bytecodes.pop(0) * 256
@@ -233,6 +239,8 @@ def _OperatorVariableClass(baseClass=object):
                     stack.append(ins.argval)
                 elif ins.opname == 'RESUME':
                     pass
+                elif ins.opname == 'BINARY_OP':
+                    stack.append(stack.pop(-2) + " " + self._binary_op[ins.argval] + " " + stack.pop())
                 elif ins.opcode in self._unop:
                     stack.append(self._unop[ins.opcode] + '(' + stack.pop() + ')')
                 elif ins.opcode in self._binop:


### PR DESCRIPTION
- [x] Something is borked with the mamba solver
- [x] Newer opcodes break `Variable` representations
- [x] PyTrilinos only installs in Python 3.7, which is fragile
- [x] Documentation build stalls on `HTML`
    ```
      File "/home/vsts/work/1/s/documentation/_themes/nist/basic_layout.html", line 97, in template
        <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
        ^^^^^^^^^^^^^^^^^^^^^^^^^
    jinja2.exceptions.UndefinedError: 'style' is undefined
    ```

One consequence of this PR is that tests are run on latest Python 3 that can be installed, instead of hard-wiring 3.10 or 3.7.