### PR TITLE
Fix numpy 1.25 issues

### DIFF
--- a/examples/phase/symmetry.py
+++ b/examples/phase/symmetry.py
@@ -69,9 +69,9 @@ The following code tests the results with a different algorithm:
 ...         x = dx * (i + 0.5)
 ...         y = dx * (j + 0.5)
 ...         testResult[i, j] = x * y
-...         bottomRight[i, j] = var(((L - x,), (y,)))
-...         topLeft[i, j] = var(((x,), (L - y,)))
-...         topRight[i, j] = var(((L - x,), (L - y,)))
+...         bottomRight[i, j] = var(((L - x,), (y,)))[0]
+...         topLeft[i, j] = var(((x,), (L - y,)))[0]
+...         topRight[i, j] = var(((L - x,), (L - y,)))[0]
 >>> numerix.allclose(testResult, bottomRight, atol = 1e-10)
 1
 >>> numerix.allclose(testResult, topLeft, atol = 1e-10)

--- a/fipy/meshes/mesh.py
+++ b/fipy/meshes/mesh.py
@@ -386,14 +386,13 @@ class Mesh(AbstractMesh):
             [[ 1.5  4.5  1.5  4.5]
              [ 1.   1.   3.   3. ]]
 
-
         but the vector must have the same dimensionality as the `Mesh`
 
             >>> dilatedMesh = baseMesh * ((3,), (2,), (1,)) #doctest: +IGNORE_EXCEPTION_DETAIL
             Traceback (most recent call last):
             ...
             ValueError: shape mismatch: objects cannot be broadcast to a single shape
-        """
+       """
         newCoords = self.vertexCoords * factor
         newmesh = Mesh(vertexCoords=newCoords,
                        faceVertexIDs=numerix.array(self.faceVertexIDs),
@@ -786,6 +785,66 @@ class Mesh(AbstractMesh):
             ... # doctest: +SERIAL
             True
 
+
+
+        Check dilation of 1D meshes
+
+            >>> from fipy.meshes import Grid1D
+            >>> baseMesh = Grid1D(dx = 1.0, nx = 2)
+            >>> print(baseMesh.cellCenters)
+            [[ 0.5  1.5]]
+
+        The `factor` can be a scalar
+
+            >>> dilatedMesh = baseMesh * 3
+            >>> print(dilatedMesh.cellCenters)
+            [[ 1.5  4.5]]
+
+        or a vector
+
+            >>> dilatedMesh = baseMesh * ((3,),)
+            >>> print(dilatedMesh.cellCenters)
+            [[ 1.5  4.5]]
+
+        but the vector must have the same dimensionality as the `Mesh`
+
+            >>> dilatedMesh = baseMesh * ((3,), (2,), (1,)) #doctest: +IGNORE_EXCEPTION_DETAIL
+            Traceback (most recent call last):
+            ...
+            ValueError: shape mismatch: objects cannot be broadcast to a single shape
+
+
+        Check dilation of 3D meshes
+
+            >>> from fipy.meshes import Grid3D
+            >>> baseMesh = Grid3D(dx = 1.0, dy = 1.0, dz = 1.0, nx = 2, ny = 2, nz = 2)
+            >>> print(baseMesh.cellCenters)
+            [[ 0.5  1.5  0.5  1.5  0.5  1.5  0.5  1.5]
+             [ 0.5  0.5  1.5  1.5  0.5  0.5  1.5  1.5]
+             [ 0.5  0.5  0.5  0.5  1.5  1.5  1.5  1.5]]
+
+        The `factor` can be a scalar
+
+            >>> dilatedMesh = baseMesh * 3
+            >>> print(dilatedMesh.cellCenters)
+            [[ 1.5  4.5  1.5  4.5  1.5  4.5  1.5  4.5]
+             [ 1.5  1.5  4.5  4.5  1.5  1.5  4.5  4.5]
+             [ 1.5  1.5  1.5  1.5  4.5  4.5  4.5  4.5]]
+
+        or a vector
+
+            >>> dilatedMesh = baseMesh * ((3,), (2,), (1,))
+            >>> print(dilatedMesh.cellCenters)
+            [[ 1.5  4.5  1.5  4.5  1.5  4.5  1.5  4.5]
+             [ 1.   1.   3.   3.   1.   1.   3.   3. ]
+             [ 0.5  0.5  0.5  0.5  1.5  1.5  1.5  1.5]]
+
+        but the vector must have the same dimensionality as the `Mesh`
+
+            >>> dilatedMesh = baseMesh * ((3,), (2,)) #doctest: +IGNORE_EXCEPTION_DETAIL
+            Traceback (most recent call last):
+            ...
+            ValueError: shape mismatch: objects cannot be broadcast to a single shape
         """
 
 def _test():

--- a/fipy/meshes/uniformGrid1D.py
+++ b/fipy/meshes/uniformGrid1D.py
@@ -249,7 +249,10 @@ class UniformGrid1D(UniformGrid):
                              overlap=self.args['overlap'])
 
     def __mul__(self, factor):
-        return UniformGrid1D(dx=self.dx * factor,
+        dx = numerix.array([[self.args['dx']]])
+        dx *= factor
+
+        return UniformGrid1D(dx=dx[0,0],
                              nx=self.args['nx'],
                              origin=self.args['origin'] * factor,
                              overlap=self.args['overlap'])

--- a/fipy/meshes/uniformGrid2D.py
+++ b/fipy/meshes/uniformGrid2D.py
@@ -425,11 +425,12 @@ class UniformGrid2D(UniformGrid):
                              origin = numerix.array(self.args['origin']) + vector, overlap=self.args['overlap'])
 
     def __mul__(self, factor):
-        if numerix.shape(factor) is ():
-            factor = numerix.resize(factor, (2, 1))
+        dxdy = numerix.array([[self.args['dx']],
+                              [self.args['dy']]])
+        dxdy *= factor
 
-        return UniformGrid2D(dx=self.args['dx'] * numerix.array(factor[0]), nx=self.args['nx'],
-                             dy=self.args['dy'] * numerix.array(factor[1]), ny=self.args['ny'],
+        return UniformGrid2D(dx=dxdy[0,0], nx=self.args['nx'],
+                             dy=dxdy[1,0], ny=self.args['ny'],
                              origin=numerix.array(self.args['origin']) * factor, overlap=self.args['overlap'])
 
     @property

--- a/fipy/meshes/uniformGrid3D.py
+++ b/fipy/meshes/uniformGrid3D.py
@@ -382,10 +382,15 @@ class UniformGrid3D(UniformGrid):
                              origin = numerix.array(self.args['origin']) + vector, overlap=self.args['overlap'])
 
     def __mul__(self, factor):
-        return UniformGrid3D(dx = self.dx * factor, nx = self.nx,
-                             dy = self.dy * factor, ny = self.ny,
-                             dz = self.dz * factor, nz = self.nz,
-                             origin = self.origin * factor)
+        dxdydz = numerix.array([[self.args['dx']],
+                                [self.args['dy']],
+                                [self.args['dz']]])
+        dxdydz *= factor
+
+        return UniformGrid3D(dx=dxdydz[0,0], nx=self.nx,
+                             dy=dxdydz[1,0], ny=self.ny,
+                             dz=dxdydz[2,0], nz=self.nz,
+                             origin=self.origin * factor)
 
     @property
     def _concatenableMesh(self):

--- a/fipy/tools/dimensions/physicalField.py
+++ b/fipy/tools/dimensions/physicalField.py
@@ -654,7 +654,7 @@ class PhysicalField(object):
         As a special case, quantities with angular units are converted to
         base units (radians) and then assumed dimensionless.
 
-            >>> print(numerix.round_(float(PhysicalField("2. deg")), 6))
+            >>> print(numerix.round(float(PhysicalField("2. deg")), 6))
             0.034907
 
         If the quantity is not dimensionless, the conversion fails.
@@ -908,7 +908,7 @@ class PhysicalField(object):
         """
         Return the `PhysicalField` without units, after conversion to base SI units.
 
-            >>> print(numerix.round_(PhysicalField("1 inch").numericValue, 6))
+            >>> print(numerix.round(PhysicalField("1 inch").numericValue, 6))
             0.0254
         """
         return self.inSIUnits().value
@@ -971,7 +971,7 @@ class PhysicalField(object):
 
         The input `PhysicalField` must be dimensionless
 
-            >>> print(numerix.round_(PhysicalField("1 m").arccos(), 6))
+            >>> print(numerix.round(PhysicalField("1 m").arccos(), 6))
             Traceback (most recent call last):
                 ...
             TypeError: Incompatible units
@@ -988,7 +988,7 @@ class PhysicalField(object):
 
         The input `PhysicalField` must be dimensionless
 
-            >>> print(numerix.round_(PhysicalField("1. m").arccosh(), 6))
+            >>> print(numerix.round(PhysicalField("1. m").arccosh(), 6))
             Traceback (most recent call last):
                 ...
             TypeError: Incompatible units
@@ -1004,7 +1004,7 @@ class PhysicalField(object):
 
         The input `PhysicalField` must be dimensionless
 
-            >>> print(numerix.round_(PhysicalField("1 m").arcsin(), 6))
+            >>> print(numerix.round(PhysicalField("1 m").arcsin(), 6))
             Traceback (most recent call last):
                 ...
             TypeError: Incompatible units
@@ -1065,9 +1065,9 @@ class PhysicalField(object):
         """
         Return the cosine of the `PhysicalField`
 
-            >>> print(numerix.round_(PhysicalField(2*numerix.pi/6, "rad").cos(), 6))
+            >>> print(numerix.round(PhysicalField(2*numerix.pi/6, "rad").cos(), 6))
             0.5
-            >>> print(numerix.round_(PhysicalField(60., "deg").cos(), 6))
+            >>> print(numerix.round(PhysicalField(60., "deg").cos(), 6))
             0.5
 
         The units of the `PhysicalField` must be an angle
@@ -1099,9 +1099,9 @@ class PhysicalField(object):
         """
         Return the tangent of the `PhysicalField`
 
-            >>> numerix.round_(PhysicalField(numerix.pi/4, "rad").tan(), 6)
+            >>> numerix.round(PhysicalField(numerix.pi/4, "rad").tan(), 6)
             1.0
-            >>> numerix.round_(PhysicalField(45, "deg").tan(), 6)
+            >>> numerix.round(PhysicalField(45, "deg").tan(), 6)
             1.0
 
         The units of the `PhysicalField` must be an angle
@@ -1133,15 +1133,15 @@ class PhysicalField(object):
         """
         Return the arctangent of `self` divided by `other` in radians
 
-            >>> print(numerix.round_(PhysicalField(2.).arctan2(PhysicalField(5.)), 6))
+            >>> print(numerix.round(PhysicalField(2.).arctan2(PhysicalField(5.)), 6))
             0.380506
 
         The input `PhysicalField` objects must be in the same dimensions
 
-            >>> print(numerix.round_(PhysicalField(2.54, "cm").arctan2(PhysicalField(1., "inch")), 6))
+            >>> print(numerix.round(PhysicalField(2.54, "cm").arctan2(PhysicalField(1., "inch")), 6))
             0.785398
 
-            >>> print(numerix.round_(PhysicalField(2.).arctan2(PhysicalField("5. m")), 6))
+            >>> print(numerix.round(PhysicalField(2.).arctan2(PhysicalField("5. m")), 6))
             Traceback (most recent call last):
                 ...
             TypeError: Incompatible units
@@ -1153,12 +1153,12 @@ class PhysicalField(object):
         """
         Return the arctangent of the `PhysicalField` in radians
 
-            >>> print(numerix.round_(PhysicalField(1).arctan(), 6))
+            >>> print(numerix.round(PhysicalField(1).arctan(), 6))
             0.785398
 
         The input `PhysicalField` must be dimensionless
 
-            >>> print(numerix.round_(PhysicalField("1 m").arctan(), 6))
+            >>> print(numerix.round(PhysicalField("1 m").arctan(), 6))
             Traceback (most recent call last):
                 ...
             TypeError: Incompatible units
@@ -1174,7 +1174,7 @@ class PhysicalField(object):
 
         The input `PhysicalField` must be dimensionless
 
-            >>> print(numerix.round_(PhysicalField("1 m").arctanh(), 6))
+            >>> print(numerix.round(PhysicalField("1 m").arctanh(), 6))
             Traceback (most recent call last):
                 ...
             TypeError: Incompatible units
@@ -1186,12 +1186,12 @@ class PhysicalField(object):
         """
         Return the natural logarithm of the `PhysicalField`
 
-            >>> print(numerix.round_(PhysicalField(10).log(), 6))
+            >>> print(numerix.round(PhysicalField(10).log(), 6))
             2.302585
 
         The input `PhysicalField` must be dimensionless
 
-            >>> print(numerix.round_(PhysicalField("1. m").log(), 6))
+            >>> print(numerix.round(PhysicalField("1. m").log(), 6))
             Traceback (most recent call last):
                 ...
             TypeError: Incompatible units
@@ -1202,12 +1202,12 @@ class PhysicalField(object):
         """
         Return the base-10 logarithm of the `PhysicalField`
 
-            >>> print(numerix.round_(PhysicalField(10.).log10(), 6))
+            >>> print(numerix.round(PhysicalField(10.).log10(), 6))
             1.0
 
         The input `PhysicalField` must be dimensionless
 
-            >>> print(numerix.round_(PhysicalField("1. m").log10(), 6))
+            >>> print(numerix.round(PhysicalField("1. m").log10(), 6))
             Traceback (most recent call last):
                 ...
             TypeError: Incompatible units
@@ -1651,7 +1651,7 @@ class PhysicalUnit(object):
 
             >>> a = PhysicalField("1. mm")
             >>> b = PhysicalField("1. inch")
-            >>> print(numerix.round_(b.unit.conversionFactorTo(a.unit), 6))
+            >>> print(numerix.round(b.unit.conversionFactorTo(a.unit), 6))
             25.4
 
         Units must have the same fundamental SI units
@@ -1691,7 +1691,7 @@ class PhysicalUnit(object):
             >>> a = PhysicalField("1. K").unit
             >>> b = PhysicalField("1. degF").unit
             >>> from builtins import str
-            >>> [str(numerix.round_(element, 6)) for element in b.conversionTupleTo(a)]
+            >>> [str(numerix.round(element, 6)) for element in b.conversionTupleTo(a)]
             ['0.555556', '459.67']
         """
         if not numerix.all(self.powers == other.powers):
@@ -1886,17 +1886,17 @@ def _Scale(quantity, scaling):
 
     `quantity` can be a `PhysicalField`
 
-        >>> print(numerix.round_(_Scale(PhysicalField("1. inch"), PhysicalField("1. mm")), 6))
+        >>> print(numerix.round(_Scale(PhysicalField("1. inch"), PhysicalField("1. mm")), 6))
         25.4
 
     or a value-unit string convertible to a `PhysicalField`
 
-        >>> print(numerix.round_(_Scale("1. inch", PhysicalField("1. mm")), 6))
+        >>> print(numerix.round(_Scale("1. inch", PhysicalField("1. mm")), 6))
         25.4
 
     or a dimensionless number. A dimensionless number is left alone.
 
-        >>> print(numerix.round_(_Scale(PhysicalField(2.), PhysicalField("1. mm")), 6))
+        >>> print(numerix.round(_Scale(PhysicalField(2.), PhysicalField("1. mm")), 6))
         2.0
 
     It is an error for the result to have dimensions.

--- a/fipy/tools/dimensions/physicalField.py
+++ b/fipy/tools/dimensions/physicalField.py
@@ -257,7 +257,7 @@ class PhysicalField(object):
             other = PhysicalField(value = other)
 
         if not isinstance(other, PhysicalField):
-            if numerix.alltrue(other == 0):
+            if numerix.all(other == 0):
                 new_value = sign1(selfValue)
             elif self.unit.isDimensionlessOrAngle() or self.unit.isInverseAngle():
                 new_value = sign1(selfValue) + sign2(other)
@@ -484,7 +484,7 @@ class PhysicalField(object):
         if not isinstance(other, PhysicalField):
             if isinstance(other, string_types):
                 other = PhysicalField(other)
-            elif numerix.alltrue(other == 0) or self.unit.isDimensionlessOrAngle():
+            elif numerix.all(other == 0) or self.unit.isDimensionlessOrAngle():
                 other = PhysicalField(value = other, unit = self.unit)
             else:
                 raise TypeError('Incompatible units')
@@ -1415,7 +1415,7 @@ class PhysicalUnit(object):
                 return self.isDimensionless()
             else:
                 raise TypeError('PhysicalUnits can only be compared with other PhysicalUnits')
-        if not numerix.alltrue(self.powers == other.powers):
+        if not numerix.all(self.powers == other.powers):
             raise TypeError('Incompatible units')
 
     def __eq__(self, other):
@@ -1673,7 +1673,7 @@ class PhysicalUnit(object):
                 ...
             TypeError: Unit conversion (K to degF) cannot be expressed as a simple multiplicative factor
         """
-        if not numerix.alltrue(self.powers == other.powers):
+        if not numerix.all(self.powers == other.powers):
             if self.isDimensionlessOrAngle() and other.isDimensionlessOrAngle():
                 return self.factor / other.factor
             else:
@@ -1694,7 +1694,7 @@ class PhysicalUnit(object):
             >>> [str(numerix.round_(element, 6)) for element in b.conversionTupleTo(a)]
             ['0.555556', '459.67']
         """
-        if not numerix.alltrue(self.powers == other.powers):
+        if not numerix.all(self.powers == other.powers):
             raise TypeError('Incompatible units')
 
         # let (s1,d1) be the conversion tuple from 'self' to base units

--- a/fipy/tools/numerix.py
+++ b/fipy/tools/numerix.py
@@ -62,6 +62,8 @@ elif arch == '64bit':
 else:
     raise Exception('Cannot set integer dtype because architecture is unknown.')
 
+py_max = max
+
 from numpy.core import umath
 from numpy import newaxis as NewAxis
 from numpy import *
@@ -914,7 +916,7 @@ def _broadcastShapes(shape1, shape2):
         if s == 0 or o == 0:
             return 0
         else:
-            return max(s, o)
+            return py_max(s, o)
 
     if logical_and.reduce([(s == o or s == 1 or o == 1) for s, o in zip(shape1, shape2)]):
         broadcastshape = tuple([maxzero(s, o) for s, o in zip(shape1, shape2)])
@@ -1093,7 +1095,7 @@ def invert_indices(arr, axis=-1):
     rev = coo_matrix(
         (NUMERIX.ones(len(fwd), dtype=int),
          (fwd[..., 0], fwd[..., 1])),
-        shape=(arr.shape[axis], max(arr.flat)+1)
+        shape=(arr.shape[axis], py_max(arr.flat)+1)
     ).tolil().T.rows
     return argstoarray(*rev).swapaxes(0, axis).astype(int)
 

--- a/fipy/tools/numerix.py
+++ b/fipy/tools/numerix.py
@@ -1099,6 +1099,11 @@ def invert_indices(arr, axis=-1):
     ).tolil().T.rows
     return argstoarray(*rev).swapaxes(0, axis).astype(int)
 
+# NumPy 1.25 deprectates `round_()` in favor of `round()`,
+# but earlier NumPy doesn't alias `round()` in `__all__`
+if "round" not in globals():
+    round = NUMERIX.round
+
 def _test():
     import fipy.tests.doctestPlus
     return fipy.tests.doctestPlus.testmod()

--- a/fipy/tools/numerix.py
+++ b/fipy/tools/numerix.py
@@ -140,7 +140,7 @@ def put(arr, ids, values):
     if _isPhysical(arr):
         arr.put(ids, values)
     elif MA.isMaskedArray(arr):
-        if NUMERIX.sometrue(MA.getmaskarray(ids)):
+        if NUMERIX.any(MA.getmaskarray(ids)):
             if numpy_version == 'old':
                 pvalues = MA.array(values, mask=MA.getmaskarray(ids))
             else:

--- a/fipy/tools/vector.py
+++ b/fipy/tools/vector.py
@@ -18,7 +18,7 @@ def _putAdd(vector, ids, additionVector, mask=False):
     """
     additionVector = numerix.array(additionVector)
 
-    if numerix.sometrue(mask):
+    if numerix.any(mask):
         if len(vector.shape) < len(additionVector.shape):
             for j in range(vector.shape[0]):
                 for id, value, masked in zip(ids.flat, additionVector[j].flat, mask.flat):

--- a/fipy/variables/meshVariable.py
+++ b/fipy/variables/meshVariable.py
@@ -532,7 +532,7 @@ class _MeshVariable(Variable):
         newOpShape, baseClass, newOther = Variable._shapeClassAndOther(self, opShape, operatorClass, other)
 
         if ((newOpShape is None or baseClass is None)
-            and numerix.alltrue(numerix.array(numerix.getShape(other)) == self.mesh.dim)):
+            and numerix.all(numerix.array(numerix.getShape(other)) == self.mesh.dim)):
                 newOpShape, baseClass, newOther = Variable._shapeClassAndOther(self, opShape, operatorClass, other[..., numerix.newaxis])
 
         return (newOpShape, baseClass, newOther)


### PR DESCRIPTION
NumPy 1.25 brings [deprecations and changes](https://numpy.org/doc/stable/release/1.25.0-notes.html) that [breaks FiPy](https://dev.azure.com/guyer/FiPy/_build/results?buildId=609&view=results).

Fixes #931 