### PR TITLE
Migrate pkg_resources to importlib

### DIFF
--- a/fipy/viewers/__init__.py
+++ b/fipy/viewers/__init__.py
@@ -96,15 +96,31 @@ def Viewer(vars, title=None, limits={}, FIPY_VIEWER=None, **kwlimits):
     if len(emptyvars):
         viewers.append(DummyViewer(vars=emptyvars))
 
-    enpts = []
-    import pkg_resources
-    for ep in pkg_resources.iter_entry_points(group='fipy.viewers',
-                                              name=FIPY_VIEWER):
-        enpts.append((ep.name, ep))
+    try:
+        # pkg_resources is depcrecated,
+        # but importlib.metadata doesn't exist until Python 3.8
+        from importlib.metadata import entry_points
 
-    for name, ep in sorted(enpts):
+        if FIPY_VIEWER is None:
+            # unlike pkg_resources.iter_entry_points,
+            # importlib.metadata.entry_points doesn't return anything
+            # if name=NONE
+            enpts = entry_points(group='fipy.viewers')
+        else:
+            enpts = entry_points(group='fipy.viewers', name=FIPY_VIEWER)
 
-        attempts.append(name)
+        enpts = sorted(entry_points(group='fipy.viewers'))
+    except ImportError:
+        from pkg_resources import iter_entry_points
+
+        enpts = iter_entry_points(group='fipy.viewers', name=FIPY_VIEWER)
+
+        # pkg_resources.EntryPoint objects aren't sortable
+        enpts = sorted(enpts, key=lambda ep: ep.name)
+
+    for ep in enpts:
+
+        attempts.append(ep.name)
 
         try:
             ViewerClass = ep.load()
@@ -119,7 +135,7 @@ def Viewer(vars, title=None, limits={}, FIPY_VIEWER=None, **kwlimits):
 
             break
         except Exception as s:
-            errors.append("%s: %s" % (name, s))
+            errors.append("%s: %s" % (ep.name, s))
 
     if len(attempts) == 0:
         if FIPY_VIEWER is not None:

--- a/fipy/viewers/__init__.py
+++ b/fipy/viewers/__init__.py
@@ -97,19 +97,30 @@ def Viewer(vars, title=None, limits={}, FIPY_VIEWER=None, **kwlimits):
         viewers.append(DummyViewer(vars=emptyvars))
 
     try:
-        # pkg_resources is depcrecated,
+        # pkg_resources is deprecated,
         # but importlib.metadata doesn't exist until Python 3.8
         from importlib.metadata import entry_points
 
-        if FIPY_VIEWER is None:
-            # unlike pkg_resources.iter_entry_points,
-            # importlib.metadata.entry_points doesn't return anything
-            # if name=NONE
-            enpts = entry_points(group='fipy.viewers')
-        else:
-            enpts = entry_points(group='fipy.viewers', name=FIPY_VIEWER)
+        enpts = entry_points()
 
-        enpts = sorted(entry_points(group='fipy.viewers'))
+        if hasattr(enpts, "select"):
+            # .select() not introduced until
+            # importlib_metadata 3.6 and Python 3.10
+
+            if FIPY_VIEWER is None:
+                # unlike pkg_resources.iter_entry_points,
+                # importlib.metadata.entry_points doesn't return anything
+                # if name=NONE
+                enpts = enpts.select(group='fipy.viewers')
+            else:
+                enpts = enpts.select(group='fipy.viewers', name=FIPY_VIEWER)
+        else:
+            enpts = enpts.get("fipy.viewers", ())
+
+            if FIPY_VIEWER is not None:
+                enpts = (mod for mod in enpts if mod.name == FIPY_VIEWER)
+
+        enpts = sorted(enpts)
     except ImportError:
         from pkg_resources import iter_entry_points
 

--- a/fipy/viewers/mayaviViewer/mayaviClient.py
+++ b/fipy/viewers/mayaviViewer/mayaviClient.py
@@ -70,10 +70,18 @@ class MayaviClient(AbstractViewer):
 
         self.plot()
 
-        from pkg_resources import Requirement, resource_filename
-        daemon_file = (daemon_file
-                       or resource_filename(Requirement.parse("FiPy"),
-                                            "fipy/viewers/mayaviViewer/mayaviDaemon.py"))
+        try:
+            from importlib import resources
+            
+            ref = resources.files("fipy") / "viewers/mayaviViewer/mayaviDaemon.py"
+            with resources.as_file(ref) as path:
+                builtin_daemon = path.as_posix()
+        except ImportError:
+            from pkg_resources import Requirement, resource_filename
+            builtin_daemon = resource_filename(Requirement.parse("FiPy"),
+                                               "fipy/viewers/mayaviViewer/mayaviDaemon.py")
+
+        daemon_file = (daemon_file or builtin_daemon)
 
         pyth = sys.executable or "python"
 


### PR DESCRIPTION
[`pkg_resources`](https://setuptools.pypa.io/en/latest/pkg_resources.html)  is deprecated, but [`importlib.resources`](https://docs.python.org/3/library/importlib.resources.html) requires Python 3.7 and [`importlib.metadata`](https://docs.python.org/3/library/importlib.metadata.html) requires Python 3.8.

Fixes #944