### PR TITLE
Issue1000 examples.diffusion.mesh1D constrains a gradient but calls it a flux

### DIFF
--- a/examples/diffusion/mesh1D.py
+++ b/examples/diffusion/mesh1D.py
@@ -379,7 +379,7 @@ to the left and a fixed gradient of
 
 to the right:
 
->>> phi = CellVariable(mesh=mesh)
+>>> phi = CellVariable(mesh=mesh, name="solution variable")
 >>> phi.faceGrad.constrain([gradRight], mesh.facesRight)
 >>> phi.constrain(valueLeft, mesh.facesLeft)
 

--- a/examples/diffusion/mesh1D.py
+++ b/examples/diffusion/mesh1D.py
@@ -373,14 +373,14 @@ The boundary conditions are a fixed value of
 
 >>> valueLeft = 0.
 
-to the left and a fixed flux of
+to the left and a fixed gradient of
 
->>> fluxRight = 1.
+>>> gradRight = 1.
 
 to the right:
 
 >>> phi = CellVariable(mesh=mesh)
->>> phi.faceGrad.constrain([fluxRight], mesh.facesRight)
+>>> phi.faceGrad.constrain([gradRight], mesh.facesRight)
 >>> phi.constrain(valueLeft, mesh.facesLeft)
 
 We re-initialize the solution variable
@@ -469,8 +469,8 @@ variables for the correct and incorrect solution
 
 >>> phiT = CellVariable(name="correct", mesh=mesh)
 >>> phiF = CellVariable(name="incorrect", mesh=mesh)
->>> phiT.faceGrad.constrain([fluxRight], mesh.facesRight)
->>> phiF.faceGrad.constrain([fluxRight], mesh.facesRight)
+>>> phiT.faceGrad.constrain([gradRight], mesh.facesRight)
+>>> phiF.faceGrad.constrain([gradRight], mesh.facesRight)
 >>> phiT.constrain(valueLeft, mesh.facesLeft)
 >>> phiF.constrain(valueLeft, mesh.facesLeft)
 >>> phiT.setValue(0)


### PR DESCRIPTION
Migration from `FixedFlux` boundary conditions to `faceGrad` constraints missed conceptual switch from boundary condition on $D\frac{\partial C}{\partial x} = J$ to $\frac{\partial C}{\partial x} = J/D$.

Fixes #1000
Addresses #999