### PR TITLE
Handle exporting anonymous conda environment

### DIFF
--- a/fipy/tools/logging/environment.py
+++ b/fipy/tools/logging/environment.py
@@ -27,7 +27,7 @@ def conda_info(conda="conda"):
     info["conda_info"] = json.loads(stdout)
 
     p = subprocess.Popen([conda, "env", "export",
-                          "--name", info["conda_info"]["active_prefix_name"],
+                          "--prefix", info["conda_info"]["active_prefix"],
                           "--json"],
                          stdout=subprocess.PIPE)
     stdout, _ = p.communicate()


### PR DESCRIPTION
`conda export env --name` doesn't work when active_prefix_name is a path (environment doesn't have a name)