### PR TITLE
Passing ax parameter explicitly to colorbar - fix issue #1087

### DIFF
--- a/fipy/viewers/matplotlibViewer/abstractMatplotlibViewer.py
+++ b/fipy/viewers/matplotlibViewer/abstractMatplotlibViewer.py
@@ -120,7 +120,8 @@ class AbstractMatplotlibViewer(AbstractViewer):
         if colorbar:
             self._colorbar = self.fig.colorbar(mappable=self._mappable,
                                                orientation=colorbar,
-                                               label=self.vars[0].name)
+                                               label=self.vars[0].name,
+                                               ax=self.axes)
 
         self.title = title
 


### PR DESCRIPTION
This pull request fixes issue #1087, by passing explicitly `self.axes` when the colorbar is created.

I am new to `fipy` so I have not tested this extensively, other than the examples listed in the issue.