### PR TITLE
Improve URL check implementation

### DIFF
--- a/docs/source/sphinxext/redirecting_html.py
+++ b/docs/source/sphinxext/redirecting_html.py
@@ -19,7 +19,7 @@ class RedirectingHTMLBuilder(StandaloneHTMLBuilder):
                 uri = node['refuri']
                 uri = urlparse(uri)
                 if uri.scheme in ["http", "https"]:
-                    if not uri.netloc.endswith("nist.gov"):
+                    if not (uri.hostname and (uri.hostname == "nist.gov" or uri.hostname.endswith(".nist.gov"))):
                         node['refuri'] = "/cgi-bin/redirect.py?url=" + uri.geturl()
             except KeyError:
                 continue


### PR DESCRIPTION
Sanitizing untrusted URLs is a common technique for preventing attacks such as request forgeries and malicious redirections. Usually, this is done by checking that the host of a URL is in a set of allowed hosts. 

Treating the URL as a string and checking if one of the allowed hosts is a substring of the URL is very prone to errors. Malicious URLs can bypass such security checks by embedding one of the allowed hosts in an unexpected location.

Even if the substring check is not used in a security-critical context, the incomplete check may still cause undesirable behaviors when the check succeeds accidentally.

