### PR TITLE
Fix BibTeX citation: escape ampersand in journal name

### DIFF
--- a/docs/source/_static/fipy.bib
+++ b/docs/source/_static/fipy.bib
@@ -3,7 +3,7 @@
    title =     {{FiPy}: Partial Differential Equations with {P}ython},
    publisher = {IEEE},
    year =      2009,
-   journal =   {Computing in Science & Engineering},
+   journal =   {Computing in Science \& Engineering},
    volume =    11,
    number =    3,
    pages =     {6-15},


### PR DESCRIPTION
Fixes #1141

The ampersand in the journal name "Computing in Science & Engineering" needs to be escaped as  for proper BibTeX formatting when users copy the citation directly into TeX documents.

This is a simple 1-character fix that prevents compilation errors.