### PR TITLE
fix: remove arrays of inhomogeneous shape and update _ModCellGradVariable

### DIFF
--- a/fipy/meshes/abstractMesh.py
+++ b/fipy/meshes/abstractMesh.py
@@ -1188,6 +1188,12 @@ class AbstractMesh(object):
         return neighborsPerCell
 
     @property
+    def _averageFaceSizePerCell(self):
+        avgFaceSize = self._faceAreas[..., self.cellFaceIDs]
+        avgFaceSize = avgFaceSize.sum(axis=0)
+        return avgFaceSize / self._facesPerCell
+
+    @property
     def _cellFaceVertices(self):
         return numerix.take(self.faceVertexIDs, self.cellFaceIDs, axis=1)
 

--- a/fipy/meshes/builders/abstractGridBuilder.py
+++ b/fipy/meshes/builders/abstractGridBuilder.py
@@ -170,7 +170,18 @@ class _AbstractGridBuilder(object):
         raise NotImplementedError
 
     def _calcPhysicalShape(self):
-        raise NotImplementedError
+        """Return physical dimensions of `Grid`
+        """
+        shape = ()
+        for ns, ds in zip(self.ns, self.ds):
+            ds = numerix.asarray(ds)
+            if len(ds.shape) == 0:
+                shape += (ns * ds * self.scale,)
+            else:
+                shape += (numerix.sum(ds) * self.scale,)
+
+        from fipy.tools.dimensions.physicalField import PhysicalField
+        return PhysicalField(value=shape)
 
     def _calcMeshSpacing(self):
         raise NotImplementedError

--- a/fipy/meshes/builders/abstractGridBuilder.py
+++ b/fipy/meshes/builders/abstractGridBuilder.py
@@ -163,8 +163,7 @@ class _AbstractGridBuilder(object):
                 self.numberOfFaces,
                 self.numberOfCells,
                 self._calcShape(),
-                self._calcPhysicalShape(),
-                self._calcMeshSpacing()]
+                self._calcPhysicalShape()]
 
     def _calcShape(self):
         raise NotImplementedError
@@ -182,9 +181,6 @@ class _AbstractGridBuilder(object):
 
         from fipy.tools.dimensions.physicalField import PhysicalField
         return PhysicalField(value=shape)
-
-    def _calcMeshSpacing(self):
-        raise NotImplementedError
 
     @property
     def _specificGridData(self):

--- a/fipy/meshes/builders/grid1DBuilder.py
+++ b/fipy/meshes/builders/grid1DBuilder.py
@@ -27,9 +27,6 @@ class _Grid1DBuilder(_AbstractGridBuilder):
     def _calcShape(self):
         return (self.ns[0],)
 
-    def _calcMeshSpacing(self):
-        return numerix.array((self.ds[0],))[..., numerix.newaxis]
-
     @staticmethod
     def createVertices(dx, nx):
         x = _AbstractGridBuilder.calcVertexCoordinates(dx, nx)

--- a/fipy/meshes/builders/grid1DBuilder.py
+++ b/fipy/meshes/builders/grid1DBuilder.py
@@ -27,11 +27,6 @@ class _Grid1DBuilder(_AbstractGridBuilder):
     def _calcShape(self):
         return (self.ns[0],)
 
-    def _calcPhysicalShape(self):
-        """Return physical dimensions of `Grid1D`."""
-        from fipy.tools.dimensions.physicalField import PhysicalField
-        return PhysicalField(value = (self.ns[0] * self.ds[0] * self.scale,))
-
     def _calcMeshSpacing(self):
         return numerix.array((self.ds[0],))[..., numerix.newaxis]
 

--- a/fipy/meshes/builders/grid2DBuilder.py
+++ b/fipy/meshes/builders/grid2DBuilder.py
@@ -21,29 +21,6 @@ class _Grid2DBuilder(_AbstractGridBuilder):
         self.numberOfVerticalColumns = self.spatialDict["numVerticalCols"]
         self.numberOfHorizontalRows = self.spatialDict["numHorizontalRows"]
 
-    def _dsUniformLen(self):
-        """
-        Return True if all entries in `self.ds` are the same length, False
-        otherwise.
-
-        Exists to get around the fact that
-        `_calcMeshSpacing` doesn't work for cylindrical grids.
-        """
-
-        # if the first entry in `ds` is non-scalar
-        if numerix.shape(self.ds[0]) != ():
-            lenDs = len(self.ds[0])
-
-            for d in self.ds[1:]:
-                if numerix.shape(d) == () or len(d) != lenDs:
-                    return False
-
-        # if any other entry in `ds` is non-scalar and first isn't
-        elif True in [numerix.shape(d) != () for d in self.ds[1:]]:
-            return False
-
-        return True
-
     def _calcShape(self):
         return (self.ns[0], self.ns[1])
 

--- a/fipy/meshes/builders/grid2DBuilder.py
+++ b/fipy/meshes/builders/grid2DBuilder.py
@@ -47,12 +47,6 @@ class _Grid2DBuilder(_AbstractGridBuilder):
     def _calcShape(self):
         return (self.ns[0], self.ns[1])
 
-    def _calcMeshSpacing(self):
-        if self._dsUniformLen():
-            return numerix.array((self.ds[0], self.ds[1]))[..., numerix.newaxis]
-        else:
-            return None
-
     @property
     def _specificGridData(self):
         return [self.numberOfHorizontalRows,

--- a/fipy/meshes/builders/grid2DBuilder.py
+++ b/fipy/meshes/builders/grid2DBuilder.py
@@ -26,8 +26,8 @@ class _Grid2DBuilder(_AbstractGridBuilder):
         Return True if all entries in `self.ds` are the same length, False
         otherwise.
 
-        Exists to get around the fact that `_calcPhysicalShape` and
-        `_calcMeshSpacing` don't work for cylindrical grids.
+        Exists to get around the fact that
+        `_calcMeshSpacing` doesn't work for cylindrical grids.
         """
 
         # if the first entry in `ds` is non-scalar
@@ -46,17 +46,6 @@ class _Grid2DBuilder(_AbstractGridBuilder):
 
     def _calcShape(self):
         return (self.ns[0], self.ns[1])
-
-    def _calcPhysicalShape(self):
-        """Return physical dimensions of `Grid2D`
-        """
-        from fipy.tools.dimensions.physicalField import PhysicalField
-
-        if self._dsUniformLen():
-            return PhysicalField(value = (self.ns[0] * self.ds[0] * self.scale,
-                                          self.ns[1] * self.ds[1] * self.scale))
-        else:
-            return None
 
     def _calcMeshSpacing(self):
         if self._dsUniformLen():

--- a/fipy/meshes/builders/grid3DBuilder.py
+++ b/fipy/meshes/builders/grid3DBuilder.py
@@ -23,14 +23,6 @@ class _Grid3DBuilder(_AbstractGridBuilder):
     def _calcShape(self):
         return (self.ns[0], self.ns[1], self.ns[2])
 
-    def _calcPhysicalShape(self):
-        """Return physical dimensions of `Grid3D`
-        """
-        from fipy.tools.dimensions.physicalField import PhysicalField
-        return PhysicalField(value = (self.ns[0] * self.ds[0] * self.scale,
-                                      self.ns[1] * self.ds[1] * self.scale,
-                                      self.ns[2] * self.ds[2] * self.scale))
-
     def _calcMeshSpacing(self):
         return numerix.array((self.ds[0], self.ds[1], self.ds[2]))[..., numerix.newaxis]
 

--- a/fipy/meshes/builders/grid3DBuilder.py
+++ b/fipy/meshes/builders/grid3DBuilder.py
@@ -23,9 +23,6 @@ class _Grid3DBuilder(_AbstractGridBuilder):
     def _calcShape(self):
         return (self.ns[0], self.ns[1], self.ns[2])
 
-    def _calcMeshSpacing(self):
-        return numerix.array((self.ds[0], self.ds[1], self.ds[2]))[..., numerix.newaxis]
-
     @property
     def _specificGridData(self):
         return [self.numberOfXYFaces,

--- a/fipy/meshes/gmshMesh.py
+++ b/fipy/meshes/gmshMesh.py
@@ -2335,10 +2335,6 @@ class GmshGrid2D(Gmsh2D):
 
         Gmsh2D.__init__(self, arg, coordDimensions, communicator, overlap, background=None)
 
-    @property
-    def _meshSpacing(self):
-        return numerix.array((self.dx, self.dy))[..., numerix.newaxis]
-
     def _makeGridGeo(self, dx, dy, nx, ny):
         height = ny * dy
         width  = nx * dx
@@ -2408,10 +2404,6 @@ class GmshGrid3D(Gmsh3D):
                                 self.nx, self.ny, self.nz)
 
         Gmsh3D.__init__(self, arg, communicator=communicator, overlap=overlap)
-
-    @property
-    def _meshSpacing(self):
-        return numerix.array((self.dx, self.dy, self.dz))[..., numerix.newaxis]
 
     def _makeGridGeo(self, dx, dy, dz, nx, ny, nz):
         height = ny * dy

--- a/fipy/meshes/nonUniformGrid1D.py
+++ b/fipy/meshes/nonUniformGrid1D.py
@@ -62,7 +62,6 @@ class NonUniformGrid1D(Mesh1D):
          self.numberOfCells,
          self.shape,
          self.physicalShape,
-         self._meshSpacing,
          self.occupiedNodes,
          vertices,
          faces,

--- a/fipy/meshes/nonUniformGrid2D.py
+++ b/fipy/meshes/nonUniformGrid2D.py
@@ -51,7 +51,6 @@ class NonUniformGrid2D(Mesh2D):
          self.numberOfCells,
          self.shape,
          self.physicalShape,
-         self._meshSpacing,
          self.numberOfHorizontalRows,
          self.numberOfVerticalColumns,
          self.numberOfHorizontalFaces,

--- a/fipy/meshes/nonUniformGrid3D.py
+++ b/fipy/meshes/nonUniformGrid3D.py
@@ -66,7 +66,6 @@ class NonUniformGrid3D(Mesh):
          self.numberOfCells,
          self.shape,
          self.physicalShape,
-         self._meshSpacing,
          self.numberOfXYFaces,
          self.numberOfXZFaces,
          self.numberOfYZFaces,

--- a/fipy/meshes/skewedGrid2D.py
+++ b/fipy/meshes/skewedGrid2D.py
@@ -72,9 +72,5 @@ class SkewedGrid2D(Mesh2D):
         return PhysicalField(value = (self.nx * self.dx * self.scale, self.ny * self.dy * self.scale))
 
     @property
-    def _meshSpacing(self):
-        return numerix.array((self.dx, self.dy))[..., numerix.newaxis]
-
-    @property
     def shape(self):
         return (self.nx, self.ny)

--- a/fipy/meshes/tri2D.py
+++ b/fipy/meshes/tri2D.py
@@ -157,10 +157,6 @@ class Tri2D(Mesh2D):
                                       self.ny * self.dy * self.scale))
 
     @property
-    def _meshSpacing(self):
-        return numerix.array((self.dx, self.dy))[..., numerix.newaxis]
-
-    @property
     def shape(self):
         return (self.nx, self.ny)
 

--- a/fipy/meshes/uniformGrid1D.py
+++ b/fipy/meshes/uniformGrid1D.py
@@ -67,7 +67,6 @@ class UniformGrid1D(UniformGrid):
          self.numberOfCells,
          self.shape,
          self.physicalShape,
-         self._meshSpacing,
          self.occupiedNodes,
          self.origin) = builder.gridData
 

--- a/fipy/meshes/uniformGrid2D.py
+++ b/fipy/meshes/uniformGrid2D.py
@@ -60,7 +60,6 @@ class UniformGrid2D(UniformGrid):
          self.numberOfCells,
          self.shape,
          self.physicalShape,
-         self._meshSpacing,
          self.numberOfHorizontalRows,
          self.numberOfVerticalColumns,
          self.numberOfHorizontalFaces,

--- a/fipy/meshes/uniformGrid3D.py
+++ b/fipy/meshes/uniformGrid3D.py
@@ -68,7 +68,6 @@ class UniformGrid3D(UniformGrid):
          self.numberOfCells,
          self.shape,
          self.physicalShape,
-         self._meshSpacing,
          self.numberOfXYFaces,
          self.numberOfXZFaces,
          self.numberOfYZFaces,

--- a/fipy/tools/numerix.py
+++ b/fipy/tools/numerix.py
@@ -458,11 +458,6 @@ else:
         ## We can't use Numeric.dot on an array of vectors
         return sqrt(dot(a1, a2))
 
-def mag(arr):
-    """Magnitude of array `arr`
-    """
-    return sqrtDot(arr, arr)
-
 def nearest(data, points, max_mem=1e8):
     """find the indices of `data` that are closest to `points`
 

--- a/fipy/tools/numerix.py
+++ b/fipy/tools/numerix.py
@@ -458,6 +458,11 @@ else:
         ## We can't use Numeric.dot on an array of vectors
         return sqrt(dot(a1, a2))
 
+def mag(arr):
+    """Magnitude of array `arr`
+    """
+    return sqrtDot(arr, arr)
+
 def nearest(data, points, max_mem=1e8):
     """find the indices of `data` that are closest to `points`
 

--- a/fipy/variables/gaussCellGradVariable.py
+++ b/fipy/variables/gaussCellGradVariable.py
@@ -66,9 +66,12 @@ class _GaussCellGradVariable(CellVariable):
 
         return self._makeValue(value = val)
 
-    def _calcValueNoInline(self, N, M, ids, orientations, volumes):
+    def _gradAreaPerCell(self, N, M, ids, orientations, volumes):
         contributions = numerix.take(self.faceGradientContributions, ids, axis=-1)
-        grad = numerix.array(numerix.sum(orientations * contributions, -2))
+        return numerix.array(numerix.sum(orientations * contributions, -2))
+
+    def _calcValueNoInline(self, N, M, ids, orientations, volumes):
+        grad = self._gradAreaPerCell(N, M, ids, orientations, volumes)
         return grad / volumes
 
     def _calcValue(self):

--- a/fipy/variables/modCellGradVariable.py
+++ b/fipy/variables/modCellGradVariable.py
@@ -25,7 +25,7 @@ class _ModCellGradVariable(_GaussCellGradVariable):
                 ITEM(val, i, vec) += ITEM(orientations, i, &k) * ITEM(areaProj, id, vec) * ITEM(faceValues, id, NULL);
             }
 
-            ITEM(val, i, vec) = mod(ITEM(val, i, vec) * ITEM(avgFaceSize, i, vec) / ITEM(avgFaceSize, i, vec);
+            ITEM(val, i, vec) = mod(ITEM(val, i, vec) * ITEM(avgFaceSize, i, vec)) / ITEM(avgFaceSize, i, vec);
             ITEM(val, i, vec) /= ITEM(volumes, i, NULL);
         """, val = val,
             ids = numerix.array(ids),

--- a/fipy/variables/modCellGradVariable.py
+++ b/fipy/variables/modCellGradVariable.py
@@ -25,8 +25,8 @@ class _ModCellGradVariable(_GaussCellGradVariable):
                 ITEM(val, i, vec) += ITEM(orientations, i, &k) * ITEM(areaProj, id, vec) * ITEM(faceValues, id, NULL);
             }
 
+            ITEM(val, i, vec) = mod(ITEM(val, i, vec) * ITEM(avgFaceSize, i, vec) /  * ITEM(avgFaceSize, i, vec);
             ITEM(val, i, vec) /= ITEM(volumes, i, NULL);
-            ITEM(val, i, vec) = mod(ITEM(val, i, vec) * gridSpacing[vec[0]]) /  gridSpacing[vec[0]];
         """, val = val,
             ids = numerix.array(ids),
             orientations = numerix.array(orientations),
@@ -35,12 +35,12 @@ class _ModCellGradVariable(_GaussCellGradVariable):
             faceValues = numerix.array(self.var.arithmeticFaceValue),
             M = M,
             ni = N,
-            gridSpacing = numerix.array(self.mesh._meshSpacing),
+            avgFaceSize = self.mesh._averageFaceSizePerCell,
             shape=numerix.array(numerix.shape(val)))
 
         return self._makeValue(value = val)
 
-    def _calcValueNoInline(self, N, M, ids, orientations, volumes):
-        value = _GaussCellGradVariable._calcValueNoInline(self, N, M, ids, orientations, volumes)
-        gridSpacing = self.mesh._meshSpacing
-        return self.modPy(value * gridSpacing) / gridSpacing
+    def _gradAreaPerCell(self, N, M, ids, orientations, volumes):
+        gradArea = super(_ModCellGradVariable, self)._gradAreaPerCell(N, M, ids, orientations, volumes)
+        avgFaceSize = self.mesh._averageFaceSizePerCell
+        return self.modPy(gradArea / avgFaceSize) * avgFaceSize

--- a/fipy/variables/modCellGradVariable.py
+++ b/fipy/variables/modCellGradVariable.py
@@ -25,7 +25,7 @@ class _ModCellGradVariable(_GaussCellGradVariable):
                 ITEM(val, i, vec) += ITEM(orientations, i, &k) * ITEM(areaProj, id, vec) * ITEM(faceValues, id, NULL);
             }
 
-            ITEM(val, i, vec) = mod(ITEM(val, i, vec) / ITEM(avgFaceSize, i, vec)) * ITEM(avgFaceSize, i, vec);
+            ITEM(val, i, vec) = mod(ITEM(val, i, vec) * ITEM(avgFaceSize, i, vec) /  * ITEM(avgFaceSize, i, vec);
             ITEM(val, i, vec) /= ITEM(volumes, i, NULL);
         """, val = val,
             ids = numerix.array(ids),
@@ -42,7 +42,5 @@ class _ModCellGradVariable(_GaussCellGradVariable):
 
     def _gradAreaPerCell(self, N, M, ids, orientations, volumes):
         gradArea = super(_ModCellGradVariable, self)._gradAreaPerCell(N, M, ids, orientations, volumes)
-        magnitude = numerix.mag(gradArea)
-        orientation = gradArea / (magnitude + numerix.finfo(float).eps)
         avgFaceSize = self.mesh._averageFaceSizePerCell
-        return self.modPy(magnitude / avgFaceSize) * avgFaceSize * orientation
+        return self.modPy(gradArea / avgFaceSize) * avgFaceSize

--- a/fipy/variables/modCellGradVariable.py
+++ b/fipy/variables/modCellGradVariable.py
@@ -25,7 +25,7 @@ class _ModCellGradVariable(_GaussCellGradVariable):
                 ITEM(val, i, vec) += ITEM(orientations, i, &k) * ITEM(areaProj, id, vec) * ITEM(faceValues, id, NULL);
             }
 
-            ITEM(val, i, vec) = mod(ITEM(val, i, vec) * ITEM(avgFaceSize, i, vec) /  * ITEM(avgFaceSize, i, vec);
+            ITEM(val, i, vec) = mod(ITEM(val, i, vec) * ITEM(avgFaceSize, i, vec) / ITEM(avgFaceSize, i, vec);
             ITEM(val, i, vec) /= ITEM(volumes, i, NULL);
         """, val = val,
             ids = numerix.array(ids),

--- a/fipy/variables/modCellGradVariable.py
+++ b/fipy/variables/modCellGradVariable.py
@@ -25,7 +25,7 @@ class _ModCellGradVariable(_GaussCellGradVariable):
                 ITEM(val, i, vec) += ITEM(orientations, i, &k) * ITEM(areaProj, id, vec) * ITEM(faceValues, id, NULL);
             }
 
-            ITEM(val, i, vec) = mod(ITEM(val, i, vec) * ITEM(avgFaceSize, i, vec) /  * ITEM(avgFaceSize, i, vec);
+            ITEM(val, i, vec) = mod(ITEM(val, i, vec) / ITEM(avgFaceSize, i, vec)) * ITEM(avgFaceSize, i, vec);
             ITEM(val, i, vec) /= ITEM(volumes, i, NULL);
         """, val = val,
             ids = numerix.array(ids),
@@ -42,5 +42,7 @@ class _ModCellGradVariable(_GaussCellGradVariable):
 
     def _gradAreaPerCell(self, N, M, ids, orientations, volumes):
         gradArea = super(_ModCellGradVariable, self)._gradAreaPerCell(N, M, ids, orientations, volumes)
+        magnitude = numerix.mag(gradArea)
+        orientation = gradArea / (magnitude + numerix.finfo(float).eps)
         avgFaceSize = self.mesh._averageFaceSizePerCell
-        return self.modPy(gradArea / avgFaceSize) * avgFaceSize
+        return self.modPy(magnitude / avgFaceSize) * avgFaceSize * orientation

--- a/fipy/variables/modCellGradVariable.py
+++ b/fipy/variables/modCellGradVariable.py
@@ -48,10 +48,29 @@ class _ModCellGradVariable(_GaussCellGradVariable):
     def _test(self):
         r"""
         >>> import fipy as fp
+        >>> from fipy.tools.numerix import pi
+
+        >>> oneDMesh = fp.Grid1D(nx=3)
+
+        Confirm that `_ModCellGradVariable` calculates as expected
+
+        >>> modVar = fp.ModularVariable(mesh=oneDMesh,
+        ...                             value=[pi/4, -3 * pi / 4, 3 * pi / 4])
+        >>> print(numerix.allclose(modVar.grad,
+        ...                        [-pi/2, -3*pi/4, -pi/4]))
+        True
+
+        Confirm that `_GaussCellGradVariable` calculates as expected
         
+        >>> nomodVar = fp.CellVariable(mesh=oneDMesh,
+        ...                            value=[pi/4, -3 * pi / 4, 3 * pi / 4])
+        >>> print(numerix.allclose(nomodVar.grad,
+        ...                        [-pi/2, pi/4, 3*pi/4]))
+        True
+
         Confirm that grids with different mesh spacings build correctly
         
-        >>> baseMesh = fp.Grid3D(dx=[0.1, 0.2, 0.15], dy=0.1, dz=0.2, ny=5, nz=10)
+        >>> threeDMesh = fp.Grid3D(dx=[0.1, 0.2, 0.15], dy=0.1, dz=0.2, ny=5, nz=10)
         """
         pass
 

--- a/fipy/variables/modCellGradVariable.py
+++ b/fipy/variables/modCellGradVariable.py
@@ -44,3 +44,20 @@ class _ModCellGradVariable(_GaussCellGradVariable):
         gradArea = super(_ModCellGradVariable, self)._gradAreaPerCell(N, M, ids, orientations, volumes)
         avgFaceSize = self.mesh._averageFaceSizePerCell
         return self.modPy(gradArea / avgFaceSize) * avgFaceSize
+
+    def _test(self):
+        r"""
+        >>> import fipy as fp
+        
+        Confirm that grids with different mesh spacings build correctly
+        
+        >>> baseMesh = fp.Grid3D(dx=[0.1, 0.2, 0.15], dy=0.1, dz=0.2, ny=5, nz=10)
+        """
+        pass
+
+def _test():
+    import fipy.tests.doctestPlus
+    return fipy.tests.doctestPlus.testmod()
+
+if __name__ == "__main__":
+    _test()

--- a/fipy/variables/test.py
+++ b/fipy/variables/test.py
@@ -26,6 +26,7 @@ def _suite():
             'fipy.variables.cellToFaceVariable',
             'fipy.variables.faceGradVariable',
             'fipy.variables.gaussCellGradVariable',
+            'fipy.variables.modCellGradVariable',
             'fipy.variables.faceGradContributionsVariable',
             'fipy.variables.surfactantConvectionVariable',
             'fipy.variables.surfactantVariable',

--- a/fipy/viewers/vtkViewer/vtkViewer.py
+++ b/fipy/viewers/vtkViewer/vtkViewer.py
@@ -161,7 +161,7 @@ class VTKViewer(AbstractViewer):
 
         >>> #     vw = VTKViewer(vars=(v1, v2))
         >>> #     vw = VTKViewer(vars=(v1, v2, v3)) #, v4, v5, v6))
-        >>> vw = VTKViewer(vars=(v4, v5, v6))
+        >>> vw = VTKViewer(vars=(v4, v5, v6)) # doctest: +TVTK
 
         >>> # vw.plot(filename="face.vtk")
         """


### PR DESCRIPTION
- Update `_ModCellGradVariable` to work with irregular meshes (previously only worked with grids).
- Remove arrays of inhomogeneous shape
  - Fix broken `_physicalSize`.
    - Never used?
  - Remove obsolete and broken `_meshSpacing`.

Fixes #1190 

> [!NOTE] 
> `--inline` implementation of `_ModCellGradVariable` has been updated, but not tested. `--inline` should be purged.
