### PR TITLE
Fix: ResidualTerm can be negated and scaled (#885)

### DIFF
--- a/fipy/terms/residualTerm.py
+++ b/fipy/terms/residualTerm.py
@@ -27,7 +27,7 @@ class ResidualTerm(_ExplicitSourceTerm):
        >>> eq = TransientTerm(var=v) == DiffusionTerm(var=v, coeff=1.)
        >>> rt = ResidualTerm(equation=eq)
 
-    valid for use with subtraction or scalar pre-multiplication.  Negation
+    valid for use with subtraction or scalar multiplication.  Negation
     flips the sign of the residual contribution:
 
        >>> sandbox = CellVariable(mesh=mesh, hasOld=True, value=0.)

--- a/fipy/terms/residualTerm.py
+++ b/fipy/terms/residualTerm.py
@@ -1,6 +1,7 @@
 __docformat__ = 'restructuredtext'
 
 from fipy.terms.explicitSourceTerm import _ExplicitSourceTerm
+from fipy.terms import TermMultiplyError
 from fipy.variables.cellVariable import CellVariable
 
 __all__ = ["ResidualTerm"]
@@ -10,15 +11,112 @@ class ResidualTerm(_ExplicitSourceTerm):
 
     The `ResidualTerm` is a special form of explicit `SourceTerm` that adds the
     residual of one equation to another equation. Useful for Newton's method.
+
+    A `ResidualTerm` can be negated or multiplied by a scalar; the residual
+    contribution is signed/scaled accordingly and the equation form is left
+    untouched (issue #885).  This makes patterns like
+
+       >>> import numpy as np
+       >>> from fipy import Grid1D, CellVariable, TransientTerm, DiffusionTerm
+       >>> from fipy.terms.residualTerm import ResidualTerm
+       >>> from fipy.matrices.scipyMatrix import _ScipyMeshMatrix
+       >>> mesh = Grid1D(nx=10, dx=1.)
+       >>> v = CellVariable(mesh=mesh, hasOld=True,
+       ...                  value=np.arange(10, dtype=float))
+       >>> v.updateOld()
+       >>> eq = TransientTerm(var=v) == DiffusionTerm(var=v, coeff=1.)
+       >>> rt = ResidualTerm(equation=eq)
+
+    valid for use with subtraction or scalar pre-multiplication.  Negation
+    flips the sign of the residual contribution:
+
+       >>> sandbox = CellVariable(mesh=mesh, hasOld=True, value=0.)
+       >>> sandbox.updateOld()
+       >>> _, _, b_pos = rt._buildAndAddMatrices(sandbox, _ScipyMeshMatrix, dt=0.1)
+       >>> _, _, b_neg = (-rt)._buildAndAddMatrices(sandbox, _ScipyMeshMatrix, dt=0.1)
+       >>> bool(np.allclose(np.asarray(b_pos), -np.asarray(b_neg)))
+       True
+
+    and a scalar multiplier scales it linearly:
+
+       >>> _, _, b_3 = (3. * rt)._buildAndAddMatrices(sandbox, _ScipyMeshMatrix, dt=0.1)
+       >>> bool(np.allclose(np.asarray(b_3), 3 * np.asarray(b_pos)))
+       True
     """
     def __init__(self, equation, underRelaxation=1.):
         self.equation = equation
         self.underRelaxation = underRelaxation
+        # Signed scale picked up by ``__neg__`` and ``__mul__``.  The default
+        # value of 1 leaves the residual contribution unchanged; ``-RT`` or
+        # ``alpha * RT`` flip / scale it without rebuilding the underlying
+        # ``equation``.  See issue #885.
+        self._scale = 1.
 
         _ExplicitSourceTerm.__init__(self, var=None)
 
     def __repr__(self):
-        return r"$\Delta$[" + repr(self.equation) + "]"
+        prefix = ""
+        if self._scale == -1.:
+            prefix = "-"
+        elif self._scale != 1.:
+            prefix = "{0!r} * ".format(self._scale)
+        return prefix + r"$\Delta$[" + repr(self.equation) + "]"
+
+    def __neg__(self):
+        r"""Negate a :class:`ResidualTerm`.
+
+        ``ResidualTerm`` carries an ``equation`` rather than the
+        ``(coeff, var)`` pair that the generic
+        :meth:`_NonDiffusionTerm.__neg__` assumes, so the inherited
+        implementation cannot be used here without raising a
+        :exc:`TypeError`.  Negation is therefore performed by flipping the
+        sign of an internal ``_scale`` multiplier that
+        :meth:`_buildMatrix` applies to the residual vector.
+
+        Regression test for issue #885:
+
+           >>> from fipy import Grid1D, CellVariable, TransientTerm
+           >>> mesh = Grid1D(nx=2)
+           >>> v = CellVariable(mesh=mesh, hasOld=True, value=1.)
+           >>> eq = TransientTerm(var=v) == 0
+           >>> from fipy.terms.residualTerm import ResidualTerm
+           >>> (-ResidualTerm(equation=eq))._scale
+           -1.0
+           >>> (-(-ResidualTerm(equation=eq)))._scale
+           1.0
+        """
+        ret = self.__class__(equation=self.equation,
+                             underRelaxation=self.underRelaxation)
+        ret._scale = -self._scale
+        return ret
+
+    def __mul__(self, other):
+        r"""Scale a :class:`ResidualTerm` by a number.
+
+        As with :meth:`__neg__`, the inherited
+        :meth:`_NonDiffusionTerm.__mul__` cannot be used because
+        ``ResidualTerm`` does not accept ``coeff`` in its constructor.
+        Scaling is folded into the internal ``_scale`` multiplier.
+
+        Regression test for issue #885:
+
+           >>> from fipy import Grid1D, CellVariable, TransientTerm
+           >>> mesh = Grid1D(nx=2)
+           >>> v = CellVariable(mesh=mesh, hasOld=True, value=1.)
+           >>> eq = TransientTerm(var=v) == 0
+           >>> from fipy.terms.residualTerm import ResidualTerm
+           >>> (2.5 * ResidualTerm(equation=eq))._scale
+           2.5
+        """
+        if isinstance(other, (int, float)):
+            ret = self.__class__(equation=self.equation,
+                                 underRelaxation=self.underRelaxation)
+            ret._scale = other * self._scale
+            return ret
+        else:
+            raise TermMultiplyError
+
+    __rmul__ = __mul__
 
     def _getGeomCoeff(self, var):
         return self.coeff
@@ -28,8 +126,18 @@ class ResidualTerm(_ExplicitSourceTerm):
                                                boundaryConditions=boundaryConditions,
                                                dt=dt)
 
-        self.coeff = CellVariable(mesh=var.mesh, value=vec * self.underRelaxation)
+        self.coeff = CellVariable(mesh=var.mesh,
+                                  value=vec * self.underRelaxation * self._scale)
         self.geomCoeff = None
         self.coeffVectors = None
 
         return _ExplicitSourceTerm._buildMatrix(self, var=var, SparseMatrix=SparseMatrix, boundaryConditions=boundaryConditions, dt=dt, transientGeomCoeff=transientGeomCoeff, diffusionGeomCoeff=diffusionGeomCoeff)
+
+
+def _test():
+    import fipy.tests.doctestPlus
+    return fipy.tests.doctestPlus.testmod()
+
+
+if __name__ == "__main__":
+    _test()

--- a/fipy/terms/test.py
+++ b/fipy/terms/test.py
@@ -16,6 +16,7 @@ def _suite():
             'exponentialConvectionTerm',
             'upwindConvectionTerm',
             'implicitSourceTerm',
+            'residualTerm',
             'coupledBinaryTerm',
             'abstractBinaryTerm',
             'unaryTerm',


### PR DESCRIPTION
# Fix: `ResidualTerm` can be negated and scaled

Fixes #885.

## Problem

`ResidualTerm` inherits `__neg__` and `__mul__` from `_NonDiffusionTerm`, which assume a `(coeff, var)` constructor signature:

```python
def __neg__(self):
    return self.__class__(coeff=-self.coeff, var=self.var)
```

`ResidualTerm`'s constructor is `__init__(self, equation, underRelaxation=1.)` — there is no `coeff` keyword — so unary minus *and* scalar multiplication both raise

```text
TypeError: __init__() got an unexpected keyword argument 'coeff'
```

That breaks the obvious cases (`-RT(eq)`, `2.0 * RT(eq)`) but, more insidiously, it also breaks every equation that puts a `ResidualTerm` on the right-hand side of `==`, because `Term.__sub__` distributes negation through the term tree:

```text
lhs == diffusion + ResidualTerm(eq)
# Term.__eq__   →  self - other
# Term.__sub__  →  self + (-other)
# _BinaryTerm.__neg__ →  (-self.term) + (-self.other)
# → _NonDiffusionTerm.__neg__(ResidualTerm) → TypeError
```

So the workaround documented in [#885](https://github.com/usnistgov/fipy/issues/885#issuecomment-1268172069) (parenthesise the LHS so the RHS never gets negated) is the only way `ResidualTerm` works inside an equation today.

## Fix

Override `__neg__` and `__mul__` on `ResidualTerm` to fold the sign/scale into a small internal `_scale` multiplier that `_buildMatrix` applies to the residual vector at solve time:

```python
self.coeff = CellVariable(mesh=var.mesh,
                          value=vec * self.underRelaxation * self._scale)
```

`underRelaxation` keeps its documented semantics (a relaxation factor); the signed/scaled contribution is the product of `underRelaxation` and `_scale`. `__neg__` and `__mul__` construct a fresh `ResidualTerm` and stamp `_scale` on it, so chains like `-(-RT)` and `2 * (3 * RT)` compose correctly.

## Verification

End-to-end at the RHS-vector level:

```python
>>> mesh = Grid1D(nx=10, dx=1.)
>>> v = CellVariable(mesh=mesh, hasOld=True, value=np.arange(10, dtype=float))
>>> v.updateOld()
>>> eq = TransientTerm(var=v) == DiffusionTerm(var=v, coeff=1.)
>>> rt = ResidualTerm(equation=eq)
>>> sandbox = CellVariable(mesh=mesh, hasOld=True, value=0.); sandbox.updateOld()
>>> _, _, b_pos = rt._buildAndAddMatrices(sandbox, _ScipyMeshMatrix, dt=0.1)
>>> _, _, b_neg = (-rt)._buildAndAddMatrices(sandbox, _ScipyMeshMatrix, dt=0.1)
>>> _, _, b_3   = (3. * rt)._buildAndAddMatrices(sandbox, _ScipyMeshMatrix, dt=0.1)
>>> np.allclose(np.asarray(b_neg), -np.asarray(b_pos))
True
>>> np.allclose(np.asarray(b_3),  3 * np.asarray(b_pos))
True
```

`b_pos = [1, 0, ..., 0, -1]` (a diffusion-only residual on a linear ramp), `b_neg = [-1, 0, ..., 0, 1]`, `b_3 = [3, 0, ..., 0, -3]`. The negation/scaling is applied exactly once per build.

All four originally-broken paths from the issue now work:

```python
-fipy.ResidualTerm(equation=eq)                                  # was TypeError
2.0 * fipy.ResidualTerm(equation=eq)                             # was TypeError
lhs == rhs + fipy.ResidualTerm(equation=eq)                      # was TypeError
lhs == rhs - fipy.ResidualTerm(equation=eq)                      # was TypeError
```

and the doctest-discovered division `RT / 4.` routes through `__rmul__` so it works too.

Doctests live in `fipy/terms/residualTerm.py` and exercise both the `_scale` bookkeeping and the numerical RHS contribution. The module is added to `fipy/terms/test.py` so `fipy_test` picks them up:

```console
$ python -c "import doctest, fipy.terms.residualTerm as m; \
              print(doctest.testmod(m, verbose=False))"
TestResults(failed=0, attempted=29)

$ python -c "import unittest, fipy.terms.test as t; \
              r = unittest.TextTestRunner(verbosity=0).run(t._suite()); \
              print(r.testsRun, len(r.failures))"
54 13
```

The 54 vs the previous 50 includes the new `residualTerm` doctests. The 13 failures are all pre-existing numpy-2.x repr-formatting drift in other terms (`[[ 1.  ...]]` vs `[[1. ...]]`), unrelated to this patch.

## Scope

`fipy/terms/residualTerm.py` (the fix + doctests) and `fipy/terms/test.py` (one line to register the new doctest module). No public API change — `ResidualTerm(equation, underRelaxation=1.)` keeps its signature; the new `_scale` is an internal field that defaults to 1 and is preserved by negation/scaling only.
