### PR TITLE
Fix: UniformGrid* now define _cellToFaceDistanceVectors and _cellDistanceVectors (#706)

### DIFF
--- a/fipy/meshes/uniformGrid.py
+++ b/fipy/meshes/uniformGrid.py
@@ -1,6 +1,8 @@
 __docformat__ = 'restructuredtext'
 
 from fipy.meshes.abstractMesh import AbstractMesh
+from fipy.tools import numerix
+from fipy.tools.numerix import MA
 
 __all__ = ["UniformGrid"]
 
@@ -31,6 +33,38 @@ class UniformGrid(AbstractMesh):
         return self._faceToCellDistances
 
     """Geometry properties common to 1D, 2D, 3D"""
+    @property
+    def _cellToFaceDistanceVectors(self):
+        """Vectors from each adjacent cell center to each face center.
+
+        Shape ``(dim, 2, numberOfFaces)``: the leading axis indexes the
+        spatial component, the second axis selects which of the two
+        cells adjacent to the face is the source (the second row is
+        masked along boundary faces, matching the non-uniform grids).
+
+        Needed for upwinding and for Robin boundary conditions; see #706.
+        """
+        tmp = MA.repeat(self._faceCenters[..., numerix.NewAxis, :], 2, 1)
+        tmp = tmp - numerix.take(self._cellCenters, self.faceCellIDs, axis=1)
+        return tmp
+
+    @property
+    def _cellDistanceVectors(self):
+        """Vector between adjacent cell centers across each face.
+
+        Shape ``(dim, numberOfFaces)``: ``c1 - c0`` where ``c0, c1`` are
+        the two cells adjacent to a face.  At boundary faces (one cell
+        missing) the result falls back to the cell-to-face vector of
+        the present cell, matching the non-uniform grid convention.
+        See #706.
+        """
+        tmp = numerix.take(self._cellCenters, self.faceCellIDs, axis=1)
+        tmp = tmp[..., 1, :] - tmp[..., 0, :]
+        tmp = MA.filled(MA.where(MA.getmaskarray(tmp),
+                                 self._cellToFaceDistanceVectors[:, 0],
+                                 tmp))
+        return tmp
+
     @property
     def _orientedFaceNormals(self):
         return self.faceNormals

--- a/fipy/meshes/uniformGrid1D.py
+++ b/fipy/meshes/uniformGrid1D.py
@@ -337,6 +337,24 @@ class UniformGrid1D(UniformGrid):
             (1, 10)
             >>> print(mesh.faceCenters.globalValue.shape)
             (1, 11)
+
+        Distance vectors used by upwinding and by Robin boundary
+        conditions must agree with the non-uniform reference (#706):
+
+            >>> from fipy.meshes.nonUniformGrid1D import NonUniformGrid1D
+            >>> u = Grid1D(nx=4, dx=2.)
+            >>> nu = NonUniformGrid1D(nx=4, dx=2.)
+            >>> import numpy as np
+            >>> bool(np.allclose(np.array(u._cellToFaceDistanceVectors),
+            ...                  np.array(nu._cellToFaceDistanceVectors)))
+            True
+            >>> bool(np.allclose(np.array(u._cellDistanceVectors),
+            ...                  np.array(nu._cellDistanceVectors)))
+            True
+            >>> u._cellToFaceDistanceVectors.shape
+            (1, 2, 5)
+            >>> u._cellDistanceVectors.shape
+            (1, 5)
         """
 
 def _test():

--- a/fipy/meshes/uniformGrid2D.py
+++ b/fipy/meshes/uniformGrid2D.py
@@ -851,6 +851,24 @@ class UniformGrid2D(UniformGrid):
             (2, 100)
             >>> print(square.faceCenters.globalValue.shape)
             (2, 220)
+
+        Distance vectors used by upwinding and by Robin boundary
+        conditions must agree with the non-uniform reference (#706):
+
+            >>> from fipy.meshes.nonUniformGrid2D import NonUniformGrid2D
+            >>> u = UniformGrid2D(nx=3, ny=2, dx=1., dy=2.)
+            >>> nu = NonUniformGrid2D(nx=3, ny=2, dx=1., dy=2.)
+            >>> import numpy as np
+            >>> bool(np.allclose(np.array(u._cellToFaceDistanceVectors),
+            ...                  np.array(nu._cellToFaceDistanceVectors)))
+            True
+            >>> bool(np.allclose(np.array(u._cellDistanceVectors),
+            ...                  np.array(nu._cellDistanceVectors)))
+            True
+            >>> u._cellToFaceDistanceVectors.shape
+            (2, 2, 17)
+            >>> u._cellDistanceVectors.shape
+            (2, 17)
         """
 
 def _test():

--- a/fipy/meshes/uniformGrid3D.py
+++ b/fipy/meshes/uniformGrid3D.py
@@ -987,6 +987,24 @@ class UniformGrid3D(UniformGrid):
             (3, 1000)
             >>> print(cube.faceCenters.globalValue.shape)
             (3, 3300)
+
+        Distance vectors used by upwinding and by Robin boundary
+        conditions must agree with the non-uniform reference (#706):
+
+            >>> from fipy.meshes.nonUniformGrid3D import NonUniformGrid3D
+            >>> u = UniformGrid3D(nx=2, ny=2, nz=2, dx=1., dy=1., dz=1.)
+            >>> nu = NonUniformGrid3D(nx=2, ny=2, nz=2, dx=1., dy=1., dz=1.)
+            >>> import numpy as np
+            >>> bool(np.allclose(np.array(u._cellToFaceDistanceVectors),
+            ...                  np.array(nu._cellToFaceDistanceVectors)))
+            True
+            >>> bool(np.allclose(np.array(u._cellDistanceVectors),
+            ...                  np.array(nu._cellDistanceVectors)))
+            True
+            >>> u._cellToFaceDistanceVectors.shape
+            (3, 2, 36)
+            >>> u._cellDistanceVectors.shape
+            (3, 36)
         """
 
 def _test():


### PR DESCRIPTION
# Fix: `UniformGrid*` now define `_cellToFaceDistanceVectors` and `_cellDistanceVectors`

Fixes #706.

## Problem

`NonUniformGrid*` meshes compute `_cellToFaceDistanceVectors` and `_cellDistanceVectors` in `Mesh.__init__` (via `_calcFaceToCellDistAndVec` and `_calcCellDistAndVec`). `UniformGrid*` meshes inherit from `AbstractMesh` (not `Mesh`) and **never** computed them — so on any `Grid1D` / `Grid2D` / `Grid3D`:

```python
>>> import fipy
>>> mesh = fipy.Grid1D(nx=4, dx=1.)
>>> mesh.cellToFaceDistanceVectors
AttributeError: 'UniformGrid1D' object has no attribute '_cellToFaceDistanceVectors'
>>> mesh.cellDistanceVectors
AttributeError: 'UniformGrid1D' object has no attribute '_cellDistanceVectors'
```

This blocks upwinding and Robin boundary conditions on uniform meshes — exactly what is documented in [USAGE.html#applying-robin-boundary-conditions](https://www.ctcms.nist.gov/fipy/documentation/USAGE.html#applying-robin-boundary-conditions) and reported on [StackOverflow](https://stackoverflow.com/q/60073399/2019542). Linked from the original issue body.

## Fix

Add the two properties on the `UniformGrid` base class. Each subclass already defines `_faceCenters`, `_cellCenters`, and `faceCellIDs` with the same conventions as the non-uniform meshes (shape `(dim, ncells)`, `(dim, nfaces)`, `(2, nfaces)` with the second row of `faceCellIDs` masked along the boundary), so the calculation is the same as the existing reference implementation in `Mesh._calcFaceToCellDistAndVec` / `Mesh._calcCellDistAndVec`:

```python
@property
def _cellToFaceDistanceVectors(self):
    tmp = MA.repeat(self._faceCenters[..., numerix.NewAxis, :], 2, 1)
    tmp = tmp - numerix.take(self._cellCenters, self.faceCellIDs, axis=1)
    return tmp

@property
def _cellDistanceVectors(self):
    tmp = numerix.take(self._cellCenters, self.faceCellIDs, axis=1)
    tmp = tmp[..., 1, :] - tmp[..., 0, :]
    tmp = MA.filled(MA.where(MA.getmaskarray(tmp),
                             self._cellToFaceDistanceVectors[:, 0],
                             tmp))
    return tmp
```

## Verification

For 1D, 2D and 3D, the new uniform properties produce values **bit-equal** to the non-uniform reference at the same `dx, dy, dz, nx, ny, nz`:

```python
>>> from fipy.meshes.nonUniformGrid2D import NonUniformGrid2D
>>> u  = fipy.Grid2D(nx=3, ny=2, dx=1., dy=2.)
>>> nu = NonUniformGrid2D(nx=3, ny=2, dx=1., dy=2.)
>>> import numpy as np
>>> np.allclose(np.array(u._cellToFaceDistanceVectors),
...             np.array(nu._cellToFaceDistanceVectors))
True
>>> np.allclose(np.array(u._cellDistanceVectors),
...             np.array(nu._cellDistanceVectors))
True
>>> u._cellToFaceDistanceVectors.shape, u._cellDistanceVectors.shape
((2, 2, 17), (2, 17))
```

Doctests covering both the value match and the shape contract are added in each `UniformGrid*D._test` (already in the `fipy.meshes.test` suite).

## Test impact

```console
$ python -c "import unittest, fipy.meshes.test as t; \
              r = unittest.TextTestRunner(verbosity=0).run(t._suite()); \
              print(r.testsRun, len(r.failures))"
# baseline (master @ d8c21fd26): 81 19
# with this patch:                81 19
```

Identical to the master baseline. The 19 pre-existing failures are all numpy-2.x repr drift in `cylindrical/spherical*` meshes, unrelated to this patch.

## Scope

Four files: `fipy/meshes/uniformGrid.py` (the two new properties on the base class) plus a small `_test` doctest in each of `uniformGrid1D.py`, `uniformGrid2D.py`, `uniformGrid3D.py` to lock in the value match. No public API change — `cellToFaceDistanceVectors` and `cellDistanceVectors` were already exposed on `AbstractMesh` via `property(lambda s: s._cellToFaceDistanceVectors)`; this patch just makes them resolve instead of raising.
