### PR TITLE
Fix: integer dx/dy/dz no longer truncate cell distances (#672)

### DIFF
--- a/fipy/meshes/builders/abstractGridBuilder.py
+++ b/fipy/meshes/builders/abstractGridBuilder.py
@@ -56,9 +56,20 @@ class _AbstractGridBuilder(object):
 
             if newD.unit.isDimensionless():
                 if type(d) in [list, tuple]:
-                    newD = numerix.array(d)
+                    # ``numerix.array(list_of_ints)`` defaults to an integer
+                    # dtype, which silently truncates the half-cell distances
+                    # (``dx/2``) used at boundary faces, so the grid
+                    # geometry must be promoted to floating-point here.
+                    # See #672.
+                    newD = numerix.array(d, dtype='d')
                 else:
-                    newD = d
+                    # ``ds[0]`` is normalised by ``newdx /= scale`` above,
+                    # which has the side effect of casting any integer
+                    # input to ``float64``.  Do the same for the trailing
+                    # dimensions so an integer ``dy``/``dz`` cannot leak
+                    # into the geometry arrays and corrupt ``_cellDistances``
+                    # via integer truncation.  See #672.
+                    newD = newD / scale
             else:
                 newD /= scale
 

--- a/fipy/meshes/uniformGrid2D.py
+++ b/fipy/meshes/uniformGrid2D.py
@@ -851,6 +851,18 @@ class UniformGrid2D(UniformGrid):
             (2, 100)
             >>> print(square.faceCenters.globalValue.shape)
             (2, 220)
+
+        Integer ``dx``/``dy`` must yield the same geometry as the float
+        equivalent, so that solving a diffusion problem on either mesh
+        produces matching cell distances and avoids the integer-truncation
+        divide-by-zero from #672:
+
+            >>> m_int = UniformGrid2D(dx=1, dy=1, nx=4, ny=4)
+            >>> m_flt = UniformGrid2D(dx=1., dy=1., nx=4, ny=4)
+            >>> bool(numerix.allclose(m_int._cellDistances, m_flt._cellDistances))
+            True
+            >>> bool(numerix.all(m_int._cellDistances > 0))
+            True
         """
 
 def _test():

--- a/fipy/meshes/uniformGrid3D.py
+++ b/fipy/meshes/uniformGrid3D.py
@@ -987,6 +987,16 @@ class UniformGrid3D(UniformGrid):
             (3, 1000)
             >>> print(cube.faceCenters.globalValue.shape)
             (3, 3300)
+
+        Integer ``dx``/``dy``/``dz`` must yield the same geometry as the
+        float equivalent (#672):
+
+            >>> m_int = UniformGrid3D(dx=1, dy=1, dz=1, nx=2, ny=2, nz=2)
+            >>> m_flt = UniformGrid3D(dx=1., dy=1., dz=1., nx=2, ny=2, nz=2)
+            >>> bool(numerix.allclose(m_int._cellDistances, m_flt._cellDistances))
+            True
+            >>> bool(numerix.all(m_int._cellDistances > 0))
+            True
         """
 
 def _test():


### PR DESCRIPTION
# Fix: integer `dx`/`dy`/`dz` no longer truncate cell distances

Fixes #672.

## Problem

Building any `Grid2D` / `Grid3D` with a plain Python `int` spacing made the boundary faces of the mesh end up at zero distance, and any downstream solve raised `RuntimeError: Factor is exactly singular` / `StagnatedSolverWarning` / `RuntimeWarning: invalid value encountered in true_divide` depending on the solver:

```python
>>> import fipy as fp
>>> mesh = fp.Grid2D(dx=1, dy=1, nx=20, ny=20)     # <-- ints
>>> phi  = fp.CellVariable(mesh=mesh, value=0.)
>>> eq   = fp.TransientTerm() == fp.DiffusionTerm(coeff=1)
>>> eq.solve(var=phi, dt=1.)
RuntimeWarning: divide by zero encountered in divide
```

Passing `dx=1.` (float) made it go away. The root cause matters because the API documents `dx` as `int or float`, and integer inputs are a foot-gun nobody has any reason to expect.

## Root cause

`_AbstractGridBuilder.buildGridData` (in `fipy/meshes/builders/abstractGridBuilder.py`) normalises `ds[0]`:

```python
newdx = PhysicalField(value = ds[0])
scale = PhysicalField(value = 1, unit = newdx.unit)
newdx /= scale                       # <-- side-effect: promotes int → float64
newDs.append(newdx)
```

That `/= scale` step is what made the first dimension's spacing land as `float64` — a `PhysicalField` divided by a same-unit `PhysicalField` returns a `float64`. The loop over `ds[1:]` did **not** do the same — for a dimensionless scalar it kept the raw input:

```python
for d in ds[1:]:
    newD = PhysicalField(value = d)
    if newD.unit.isDimensionless():
        if type(d) in [list, tuple]:
            newD = numerix.array(d)   # <-- inherits dtype=int from a list of ints
        else:
            newD = d                  # <-- raw Python int leaks through
    else:
        newD /= scale
    newDs.append(newD)
```

so `self.dy` / `self.dz` ended up as Python `int`. Geometry routines like `UniformGrid2D._cellDistances` then do

```python
Hdis = numerix.repeat((self.dy,), self.numberOfHorizontalFaces)
# ^ inherits the dtype of self.dy — int when dy is int
...
Hdis[..., 0]  = self.dy / 2.   # 0.5 truncated to 0 because Hdis is int
Hdis[..., -1] = self.dy / 2.
```

so every boundary face landed at distance `0`, and any solver that divided through the face areas blew up.

## Fix

Run the trailing dimensionless scalar through the same `newD = newD / scale` promotion as `ds[0]`, and pin the list/tuple branch to `dtype='d'`:

```python
if newD.unit.isDimensionless():
    if type(d) in [list, tuple]:
        # numerix.array(list_of_ints) defaults to int dtype; promote.
        newD = numerix.array(d, dtype='d')
    else:
        # Mirror the implicit float promotion done on ds[0] above.
        newD = newD / scale
```

`NonUniformGrid*` was hit by the same int-vs-float asymmetry on `dy` / `dz` (verified — `NonUniformGrid2D(dx=1, dy=1, …).dy` was previously a Python `int`), so the same change resolves the dy/dz/`[1, 2, 1]` paths in one place.

## Verification

```python
>>> import warnings, fipy
>>> warnings.simplefilter('error', RuntimeWarning)

>>> for dx, dy in [(1, 1), (1., 1), (1, 1.), (1., 1.)]:
...     mesh = fipy.Grid2D(dx=dx, dy=dy, nx=20, ny=20)
...     phi  = fipy.CellVariable(mesh=mesh, value=0.)
...     eq   = fipy.TransientTerm() == fipy.DiffusionTerm(coeff=1)
...     eq.solve(var=phi, dt=1.)
...     print(dx, dy, "OK", mesh.dx, mesh.dy, type(mesh.dx).__name__,
...           type(mesh.dy).__name__)
1 1 OK 1.0 1.0 float64 float64
1.0 1 OK 1.0 1.0 float64 float64
1 1.0 OK 1.0 1.0 float64 float64
1.0 1.0 OK 1.0 1.0 float64 float64

>>> # 3D, including the (float, float, int) case which was also broken
>>> mesh = fipy.Grid3D(dx=1, dy=1, dz=1, nx=5, ny=5, nz=5)
>>> mesh.dx, mesh.dy, mesh.dz
(1.0, 1.0, 1.0)

>>> # _cellDistances is bit-equal to the float-spaced mesh
>>> from fipy.tools import numerix
>>> int_mesh   = fipy.Grid2D(dx=1, dy=1, nx=4, ny=4)
>>> float_mesh = fipy.Grid2D(dx=1., dy=1., nx=4, ny=4)
>>> numerix.allclose(int_mesh._cellDistances, float_mesh._cellDistances)
True
>>> bool(numerix.all(int_mesh._cellDistances > 0))
True
```

Doctests are added in `UniformGrid2D._test` and `UniformGrid3D._test` pinning the `numerix.allclose(int_mesh._cellDistances, float_mesh._cellDistances)` invariant.

## Test impact

```console
$ python -c "import unittest, fipy.meshes.test as t; \
              r = unittest.TextTestRunner(verbosity=0).run(t._suite()); \
              print(r.testsRun, len(r.failures))"
# baseline (master @ d8c21fd26): 81 19
# with this patch:                81 19
```

Identical to the master baseline. The 19 pre-existing failures are all numpy-2.x repr drift in `cylindrical/spherical*` meshes, unrelated to this patch.

## Scope

Three files: `fipy/meshes/builders/abstractGridBuilder.py` (the one-block fix in the spacing-normalisation loop, with comments referencing #672) plus a small `_test` doctest in each of `uniformGrid2D.py` and `uniformGrid3D.py` to lock in the invariant. No public API change.
