### PR TITLE
fix(variables): handle new Python 3.14 bytecode opcodes

### DIFF
--- a/fipy/variables/operatorVariable.py
+++ b/fipy/variables/operatorVariable.py
@@ -152,6 +152,9 @@ def _OperatorVariableClass(baseClass=object):
                         return s
                 elif ins.opname == 'LOAD_CONST':
                     stack.append(ins.argval)
+                elif ins.opname == 'LOAD_SMALL_INT':
+                    # New in Python 3.14 (small ints no longer use LOAD_CONST)
+                    stack.append(ins.argval)
                 elif ins.opname in ['LOAD_ATTR', 'LOAD_METHOD']:
                     # LOAD_METHOD new in Python 3.7
                     stack.append(stack.pop() + "." + ins.argval)
@@ -160,10 +163,12 @@ def _OperatorVariableClass(baseClass=object):
                 elif ins.opname == 'LOAD_GLOBAL':
                     # Changed in Python 3.11
                     stack.append(ins.argval)
-                elif ins.opname == 'LOAD_FAST':
+                elif ins.opname in ['LOAD_FAST', 'LOAD_FAST_BORROW']:
+                    # LOAD_FAST_BORROW new in Python 3.14
                     stack.append(self.__var(ins.arg, style=style, argDict=argDict, id=id, freshen=freshen))
-                elif ins.opname == 'LOAD_FAST_LOAD_FAST':
-                    # New in Python 3.13
+                elif ins.opname in ['LOAD_FAST_LOAD_FAST', 'LOAD_FAST_BORROW_LOAD_FAST_BORROW']:
+                    # LOAD_FAST_LOAD_FAST new in Python 3.13;
+                    # LOAD_FAST_BORROW_LOAD_FAST_BORROW new in Python 3.14
                     for arg in range(len(self.var)):
                         stack.append(self.__var(arg, style=style, argDict=argDict, id=id, freshen=freshen))
                 elif ins.opname in ['CALL_FUNCTION', 'CALL_METHOD']:
@@ -188,7 +193,12 @@ def _OperatorVariableClass(baseClass=object):
                     pass
                 elif ins.opname == 'BINARY_OP':
                     # New in Python 3.11
-                    stack.append(stack.pop(-2) + " " + ins.argrepr + " " + stack.pop())
+                    if ins.argrepr == '[]':
+                        # Subscript is a BINARY_OP (NB_SUBSCR) in Python 3.14;
+                        # earlier versions emit BINARY_SUBSCR (handled above)
+                        stack.append(stack.pop(-2) + "[" + str(stack.pop()) + "]")
+                    else:
+                        stack.append(stack.pop(-2) + " " + ins.argrepr + " " + stack.pop())
                 elif ins.opname == 'PRECALL':
                     # New in Python 3.11
                     pass


### PR DESCRIPTION
## Description

Fixes #1171.

`_OperatorVariable._getRepresentation` (`fipy/variables/operatorVariable.py`) disassembles the operator lambda's bytecode and dispatches on opcode *names* to rebuild a Python/C string representation of the expression. Any opcode it does not recognise falls through to `raise SyntaxError("Unknown instruction: ...")`.

Python 3.14 introduces several new opcodes, so on 3.14 **every** operator variable (`a + b`, `-a`, `a[i]`, …) raises `SyntaxError` when its representation/C-string is built:

- **`LOAD_FAST_BORROW`** and **`LOAD_FAST_BORROW_LOAD_FAST_BORROW`** — borrowed-reference variants of `LOAD_FAST` / `LOAD_FAST_LOAD_FAST` (a refcounting optimization with identical operand semantics). Folded into the existing branches.
- **`LOAD_SMALL_INT`** — small integers no longer go through `LOAD_CONST`. Handled identically (push the value).
- **subscripting** is now emitted as a `BINARY_OP` with a `[]` argument rather than the old `BINARY_SUBSCR` opcode. Special-cased so it still renders as `a[b]`.

## Reproduction (Python 3.14)

```python
from fipy import Grid1D, CellVariable
m = Grid1D(nx=3)
v = CellVariable(mesh=m, value=[1., 2., 3.])
(v * 2 + 1)._getCstring(id="")
```

Before (Python 3.14.5):
```
SyntaxError: Unknown instruction: Instruction(opname='LOAD_FAST_BORROW_LOAD_FAST_BORROW', ...)
```
and `-v` raises the same for `LOAD_FAST_BORROW`, `v[1]` for the subscript change.

After:
```
((var00[i] * var01) + var1)
```

## Verification

Built representative operators on **Python 3.14.5** (numpy 2.4.6, scipy 1.17.1) and confirmed correct output and computed values:

| expression | C representation | value |
| --- | --- | --- |
| `v*2 + 1` | `((var00[i] * var01) + var1)` | `[3 5 7]` |
| `(v+1)*(v-2)` | `((var00[i] + var01) * (var10[i] - var11))` | `[-2 0 4]` |
| `-v` | `-var0[i]` | `[-1 -2 -3]` |
| `v[1]` | `Variable(...)[1]` | — |

The existing doctests in `operatorVariable.py` already exercise binary, unary, subscript, comparison, function-call (`numerix.sin`) and nested operators. With the fix they **pass on Python 3.14** and remain unchanged on earlier versions — the new opcode names simply never appear before 3.14, so the added branches are inert (verified the same doctests still pass on Python 3.11). Ran with the harness's `numpy.set_printoptions(legacy="1.13")`.

`pyspelling -c .pyspelling.yml -n python -S fipy/variables/operatorVariable.py` reports only the pre-existing "Hilliard" token (present on `master`, unrelated to this change; the python filter does not check comments).
