### PR TITLE
fix(solvers): pyamgx solvers crash on instantiation due to precon attribute typo

### DIFF
--- a/fipy/solvers/pyamgx/pyAMGXSolver.py
+++ b/fipy/solvers/pyamgx/pyAMGXSolver.py
@@ -35,15 +35,16 @@ class PyAMGXSolver(Solver):
         **kwargs
             Other AMGX solver options
         """
-        super(PyAMGXSolver, self).__init__(tolerance=tolerance, criterion=criterion, iterations=iterations)
+        super(PyAMGXSolver, self).__init__(tolerance=tolerance, criterion=criterion,
+                                           iterations=iterations, precon=precon)
 
         # update solver config:
         self.config_dict = self.CONFIG_DICT.copy()
 
         self.config_dict["solver"]["max_iters"] = self.iterations
 
-        if self.precon is not None:
-            self.precon._applyToSolver(self.config_dict["solver"])
+        if self.preconditioner is not None:
+            self.preconditioner._applyToSolver(self.config_dict["solver"])
 
         smoother = self.value_or_default(smoother, self.default_smoother)
         if smoother is not None:


### PR DESCRIPTION
Fixes #1199.

### Problem
Instantiating any pyamgx-backed solver raises immediately, before any GPU work:

```python
>>> from fipy.solvers.pyamgx import LinearGMRESSolver
>>> LinearGMRESSolver()
AttributeError: 'LinearGMRESSolver' object has no attribute 'precon'
```

`PyAMGXSolver.__init__` checks `self.precon`, but the base `Solver` stores the
preconditioner on `self.preconditioner` (set from the `precon` argument via
`value_or_default(precon, default_preconditioner)`). There is no `self.precon`
attribute, so construction fails.

This matches the maintainer’s diagnosis in #1199 ("it looks like there’s a typo … that should be `if self.preconditioner is not None: self.preconditioner._applyToSolver(...)`"), and the reporter confirmed that renaming it removes the error.

### Fix
1. Use `self.preconditioner` instead of the non-existent `self.precon`.
2. Forward `precon=precon` to the base `Solver.__init__`, matching `scipySolver`
   and `petscKrylovSolver`. Without this, both an explicitly passed `precon`
   **and** the pyamgx solvers’ class `DEFAULT_PRECONDITIONER` were silently
   dropped — the base initializes `self.preconditioner` from its `precon` arg,
   which previously defaulted to `"default"` → `None` for every pyamgx solver.

```python
super(PyAMGXSolver, self).__init__(tolerance=tolerance, criterion=criterion,
                                   iterations=iterations, precon=precon)
...
if self.preconditioner is not None:
    self.preconditioner._applyToSolver(self.config_dict["solver"])
```

### Verification
- `py_compile` clean; no remaining `self.precon` reference.
- Verified by code inspection and consistency with the sibling `scipySolver` /
  `petscKrylovSolver` `__init__` signatures, plus the maintainer diagnosis and
  reporter confirmation in #1199.
- Not runtime-tested locally: pyamgx requires the AMGX library and an NVIDIA
  GPU, which are unavailable in this environment, so I could not add a
  CI-runnable regression test without that dependency. Happy to add one if there
  is a pyamgx-capable CI lane I can target.