### PR TITLE
Honor iterations in SciPy LinearLUSolver instead of capping at 10

### DIFF
--- a/fipy/solvers/scipy/linearLUSolver.py
+++ b/fipy/solvers/scipy/linearLUSolver.py
@@ -10,6 +10,28 @@ __all__ = ["LinearLUSolver"]
 
 class LinearLUSolver(ScipySolver):
     """Interface to :term:`LU`-factorization in :ref:`SciPy`.
+
+    The number of iterative refinement sweeps honors the `iterations`
+    argument, consistent with the other `LinearLUSolver` implementations
+    (`GH #1208 <https://github.com/usnistgov/fipy/issues/1208>`_).  Forcing
+    an unreachable tolerance runs the full count rather than capping at 10:
+
+    >>> import warnings
+    >>> import fipy as fp
+    >>> mesh = fp.Grid1D(nx=10)
+    >>> var = fp.CellVariable(mesh=mesh)
+    >>> var.constrain(0., where=mesh.facesLeft)
+    >>> var.constrain(1., where=mesh.facesRight)
+    >>> eq = fp.DiffusionTerm() == 0
+    >>> solver = LinearLUSolver(iterations=12, tolerance=0.)
+    >>> solver = eq._prepareLinearSystem(var=var, solver=solver,
+    ...                                  boundaryConditions=(), dt=1.)
+    >>> L, x, b = solver._Lxb
+    >>> with warnings.catch_warnings():
+    ...     warnings.simplefilter("ignore")
+    ...     _ = solver._solve_(L, x, b)
+    >>> print(solver.convergence.iterations)
+    12
     """
 
     def _adaptLegacyTolerance(self, L, x, b):
@@ -65,7 +87,7 @@ class LinearLUSolver(ScipySolver):
                       panel_size=10,
                       permc_spec=3)
 
-            for iteration in range(min(self.iterations, 10)):
+            for iteration in range(self.iterations):
                 residualVector, residual = self._residualVectorAndNorm(L, x, b)
 
                 if residual <= self.tolerance * tolerance_scale:

--- a/fipy/solvers/test.py
+++ b/fipy/solvers/test.py
@@ -2,11 +2,15 @@ __all__ = []
 
 from fipy.tests.doctestPlus import _LateImportDocTestSuite
 import fipy.tests.testProgram
+from fipy.solvers import solver_suite
+
+docTestModuleNames = ['solver']
+if solver_suite == 'scipy':
+    docTestModuleNames.append('scipy.linearLUSolver')
 
 def _suite():
-    return _LateImportDocTestSuite(docTestModuleNames = (
-            'solver',
-            ), base = __name__)
+    return _LateImportDocTestSuite(docTestModuleNames=docTestModuleNames,
+                                   base=__name__)
 
 if __name__ == '__main__':
     fipy.tests.testProgram.main(defaultTest='_suite')


### PR DESCRIPTION
Fixes #1208.

## Problem

The SciPy `LinearLUSolver` runs its iterative-refinement loop over `range(min(self.iterations, 10))` ([`linearLUSolver.py:68`](https://github.com/usnistgov/fipy/blob/d8c21fd266f7792bdc9b3221b683e76b28e2a220/fipy/solvers/scipy/linearLUSolver.py#L68)), silently capping the user-requested iteration count at 10. The PETSc and Trilinos `LinearLUSolver` implementations both loop over `range(self.iterations)` with no such cap, so the SciPy backend was inconsistent and ignored `iterations` set above 10.

As discussed in the issue, LU refinement rarely needs more than a couple of sweeps, but users should still be able to set `iterations` to whatever they want.

## Fix

Drop the cap so the SciPy solver honors `iterations` like the other backends. The refinement loop still `break`s as soon as the residual meets the tolerance, so well-conditioned systems converge in the same one-to-few sweeps as before; only an explicit request for more (or fewer) sweeps is now respected.

## Test

Adds a regression doctest to `LinearLUSolver`, registered for the SciPy solver suite in `fipy/solvers/test.py` (mirroring the backend-conditional registration in `fipy/matrices/test.py`). With an unreachable `tolerance=0.` the loop runs the full requested count, so `iterations=12` records 12 refinement sweeps — it recorded 10 before this change.