### PR TITLE
Update fipy.bib

### DIFF
--- a/docs/source/_static/fipy.bib
+++ b/docs/source/_static/fipy.bib
@@ -3,7 +3,7 @@
    title =     {{FiPy}: Partial Differential Equations with {P}ython},
    publisher = {IEEE},
    year =      2009,
-   journal =   {Computing in Science & Engineering},
+   journal =   {Computing in Science \& Engineering},
    volume =    11,
    number =    3,
    pages =     {6-15},


### PR DESCRIPTION
Escape an ampersand character in a BibTeX entry that is linked to on the main page: https://pages.nist.gov/fipy/en/stable/

Otherwise LaTeX will give an error:

`Misplaced alignment tab character &.`