### PR TITLE
Respect requested iteration count in SciPy LinearLUSolver

### DIFF
--- a/fipy/solvers/scipy/linearLUSolver.py
+++ b/fipy/solvers/scipy/linearLUSolver.py
@@ -65,7 +65,7 @@ class LinearLUSolver(ScipySolver):
                       panel_size=10,
                       permc_spec=3)
 
-            for iteration in range(min(self.iterations, 10)):
+            for iteration in range(self.iterations):
                 residualVector, residual = self._residualVectorAndNorm(L, x, b)
 
                 if residual <= self.tolerance * tolerance_scale:


### PR DESCRIPTION
Small fix for #1208. The SciPy LinearLUSolver caps its refinement loop at min(self.iterations, 10), so asking for more than 10 iterations quietly gets clamped, which none of the other LinearLUSolver backends do. This drops the min(..., 10) so the loop respects whatever count you pass, while keeping the existing break on convergence so well-conditioned systems still finish in a couple of steps. I checked with an ill-conditioned system that requesting 25 or 50 iterations now reports the full count instead of stopping at 10, and default well-conditioned solves still exit early as before. Thanks @guyer for confirming the direction in the issue.